### PR TITLE
-view three for greater or fewer than three monitors

### DIFF
--- a/src/bzflag/BackgroundRenderer.cxx
+++ b/src/bzflag/BackgroundRenderer.cxx
@@ -566,9 +566,7 @@ void BackgroundRenderer::renderSky(SceneRenderer& renderer, bool fullWindow,
 
     // draw ground -- first get the color (assume it's all green)
     GLfloat _groundColor = 0.1f + 0.15f * renderer.getSunColor()[1];
-    if (fullWindow && viewType == SceneRenderer::ThreeChannel)
-      glScissor(x, y, width, height >> 1);
-    else if (fullWindow && viewType == SceneRenderer::Stacked)
+    if (fullWindow && viewType == SceneRenderer::Stacked)
       glScissor(x, y, width, height >> 1);
 #ifndef USE_GL_STEREO
     else if (fullWindow && viewType == SceneRenderer::Stereo)
@@ -614,9 +612,7 @@ void BackgroundRenderer::renderGround(SceneRenderer& renderer,
 
     // draw ground -- first get the color (assume it's all green)
     GLfloat _groundColor = 0.1f + 0.15f * renderer.getSunColor()[1];
-    if (fullWindow && viewType == SceneRenderer::ThreeChannel)
-      glScissor(x, y, width, height >> 1);
-    else if (fullWindow && viewType == SceneRenderer::Stacked)
+    if (fullWindow && viewType == SceneRenderer::Stacked)
       glScissor(x, y, width, height >> 1);
 #ifndef USE_GL_STEREO
     else if (fullWindow && viewType == SceneRenderer::Stereo)

--- a/src/bzflag/MainWindow.cxx
+++ b/src/bzflag/MainWindow.cxx
@@ -241,6 +241,27 @@ void			MainWindow::setQuadrant(Quadrant _quadrant)
       xOrigin = 0;
       yOrigin = 0;
       break;
+    case LeftChannel:
+      width = inWidth / 3;
+      height = inHeight;
+      viewHeight = height;
+      xOrigin = 0;
+      yOrigin = 0;
+      break;
+    case CenterChannel:
+      width = inWidth / 3;
+      height = inHeight;
+      viewHeight = height;
+      xOrigin = inWidth / 3;
+      yOrigin = 0;
+      break;
+    case RightChannel:
+      width = inWidth / 3;
+      height = inHeight;
+      viewHeight = height;
+      xOrigin = inWidth / 3 * 2;
+      yOrigin = 0;
+      break;
   }
 
   if (quadrant == ZoomRegion) {

--- a/src/bzflag/MainWindow.h
+++ b/src/bzflag/MainWindow.h
@@ -36,7 +36,10 @@ class MainWindow {
 			LowerRight,
 			ZoomRegion,
 			UpperHalf,
-			LowerHalf
+			LowerHalf,
+			LeftChannel,
+			CenterChannel,
+			RightChannel
     };
 
 			MainWindow(BzfWindow*, BzfJoystick*);

--- a/src/bzflag/bzflag.cxx
+++ b/src/bzflag/bzflag.cxx
@@ -1303,7 +1303,7 @@ int			main(int argc, char** argv)
 
   // set window quadrant
   if (RENDERER.getViewType() == SceneRenderer::ThreeChannel)
-    pmainWindow->setQuadrant(MainWindow::UpperRight);
+    pmainWindow->setQuadrant(MainWindow::FullWindow);
   else if (RENDERER.getViewType() == SceneRenderer::Stacked)
     pmainWindow->setQuadrant(MainWindow::LowerHalf);
 #ifndef USE_GL_STEREO

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -5718,11 +5718,11 @@ void drawFrame(const float dt)
     // draw frame
     if (viewType == SceneRenderer::ThreeChannel) {
       // draw center channel
+      mainWindow->setQuadrant(MainWindow::CenterChannel);
       sceneRenderer->render(false);
-      drawUI();
 
       // set up for drawing left channel
-      mainWindow->setQuadrant(MainWindow::LowerLeft);
+      mainWindow->setQuadrant(MainWindow::LeftChannel);
       // FIXME -- this assumes up is along +z
       const float cFOV = cosf(fov);
       const float sFOV = sinf(fov);
@@ -5735,7 +5735,7 @@ void drawFrame(const float dt)
       sceneRenderer->render(false, true, true);
 
       // set up for drawing right channel
-      mainWindow->setQuadrant(MainWindow::LowerRight);
+      mainWindow->setQuadrant(MainWindow::RightChannel);
       // FIXME -- this assumes up is along +z
       targetPoint[0] = eyePoint[0] + cFOV*myTankDir[0] + sFOV*myTankDir[1];
       targetPoint[1] = eyePoint[1] + cFOV*myTankDir[1] - sFOV*myTankDir[0];
@@ -5757,8 +5757,9 @@ void drawFrame(const float dt)
       // draw rear channel
       sceneRenderer->render(true, true, true);
 #endif
-      // back to center channel
-      mainWindow->setQuadrant(MainWindow::UpperRight);
+      // draw UI over everything
+      mainWindow->setQuadrant(MainWindow::FullWindow);
+      drawUI();
     } else if (viewType == SceneRenderer::Stacked) {
       float EyeDisplacement = 0.25f * BZDBCache::tankWidth;
       float FocalPlane = BZDB.eval(StateDatabase::BZDB_BOXBASE);


### PR DESCRIPTION
bzflag -view three currently puts the center view on the top-right, and the side views on the bottom corners. This requires one to have a number of monitors that is divisible into three parts, each part filling one of the views in virtual desktop space. For example, one large monitor for the center view, two narrow ones for the left view, and four small monitors for the right view. No monitor can cross a view boundary, because no views have the corresponding sides touching.
Assuming someone had a 2x2 monitor array for their desktop, to use the current -view three, they'd have to physically move the bottom-right monitor to the right, and the top-right monitor down into the new gap. Or, if they had a 3x1 monitor array for their desktop, they'd have to reassign them to quadrants instead of thirds.
I moved the three views so that they are next to each other in the correct order from the start. This would normally make the center view narrow enough that the gui freezes trying to render. To work around that, the gui now renders as if it is using -view normal. That is, the gui is rendered after the views, on top of them all, taking up the entire screen space.
This change makes -view three compatible with any size of rectangular monitor array, as long as they entirely cover the virtual desktop.
I believe this satisfies the original intention of multi-monitor widescreen gaming.
If anyone can find a reason why losing the original behavior would break someone's multi-monitor setup, please tell me.
