### PR TITLE
Use cURL to (de/en)code strings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@
 BZFlag 2.4.9
 ------------
 
+* TextUtils::url_encode and TextUtils::url_decode now use cURL's functions; this
+    change fixes a crash bug with bz_urlEncode() - Vladimir Jimenez
 * Add bz_reloadBadwords() to API - Vladimir Jimenez
 * Add ability to reload badwords list with '/reload badwords' - Vladimir Jimenez
 * Source code now dual licensed under the MPL 2.0 or LGPL 2.1 - Tim Riker

--- a/src/common/TextUtils.cxx
+++ b/src/common/TextUtils.cxx
@@ -243,18 +243,12 @@ namespace TextUtils
 
   std::string url_encode(const std::string &text)
   {
-    CURL *curl = curl_easy_init();
     std::string encoded = "";
+    char *output = curl_easy_escape(NULL, text.c_str(), 0);
 
-    if (curl) {
-      char *output = curl_easy_escape(curl, text.c_str(), 0);
-
-      if (output) {
-	encoded = output;
-	curl_free(output);
-      }
-
-      curl_easy_cleanup(curl);
+    if (output) {
+      encoded = output;
+      curl_free(output);
     }
 
     return encoded;
@@ -262,18 +256,12 @@ namespace TextUtils
 
   std::string url_decode(const std::string &text)
   {
-    CURL *curl = curl_easy_init();
     std::string decoded = "";
+    char *output = curl_easy_unescape(NULL, text.c_str(), 0, NULL);
 
-    if (curl) {
-      char *output = curl_easy_unescape(curl, text.c_str(), 0, NULL);
-
-      if (output) {
-	decoded = output;
-	curl_free(output);
-      }
-
-      curl_easy_cleanup(curl);
+    if (output) {
+      decoded = output;
+      curl_free(output);
     }
 
     return decoded;


### PR DESCRIPTION
Our current `TextUtils::url_encode()` has a buffer overflow issue when trying to encode non-ASCII characters and our `TextUtils::url_decode()` doesn't correctly decode non-ASCII charcters. Since cURL already provides [`curl_easy_escape()`](https://curl.haxx.se/libcurl/c/curl_easy_escape.html) and [`curl_easy_unescape`](https://curl.haxx.se/libcurl/c/curl_easy_unescape.html), I've changed our TextUtils functions to use those instead of our own implementations.

This issue directly affects `bz_urlEncode()` in our plug-in API and can lead to server crashes.

**bz_urlEncode() Input**

`This is a test. Here is a funny symbol: ß`

**Output**

`This+is+a+test%2E+Here+is+a+funny+symbol%3A+%FFFFFFC3%FFFFFF9F`

**Expected Output**

`This%20is%20a%20test.%20Here%20is%20a%20funny%20symbol%3A%20%C3%9F`

Can I get feedback on this as to whether this is the correct approach or not? Or how it can be improved?
