### PR TITLE
Update Model tool and remove link to common

### DIFF
--- a/tools/modeltool/MSVC/modeltool.sln
+++ b/tools/modeltool/MSVC/modeltool.sln
@@ -1,8 +1,8 @@
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "modeltool", "modeltool.vcxproj", "{75BC8894-499A-441C-B21B-875CA252507A}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "regex", "..\..\..\MSVC\build\regex.vcxproj", "{6DD493F8-31E1-4958-A240-D157AFFCB07E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,10 +13,6 @@ Global
 		{75BC8894-499A-441C-B21B-875CA252507A}.Debug|Win32.ActiveCfg = Debug|Win32
 		{75BC8894-499A-441C-B21B-875CA252507A}.Debug|Win32.Build.0 = Debug|Win32
 		{75BC8894-499A-441C-B21B-875CA252507A}.Release|Win32.ActiveCfg = Release|Win32
-		{6DD493F8-31E1-4958-A240-D157AFFCB07E}.Debug|Win32.ActiveCfg = Debug|Win32
-		{6DD493F8-31E1-4958-A240-D157AFFCB07E}.Debug|Win32.Build.0 = Debug|Win32
-		{6DD493F8-31E1-4958-A240-D157AFFCB07E}.Release|Win32.ActiveCfg = Release|Win32
-		{6DD493F8-31E1-4958-A240-D157AFFCB07E}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/modeltool/MSVC/modeltool.vcxproj
+++ b/tools/modeltool/MSVC/modeltool.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -18,10 +18,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -47,8 +49,8 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../../../include/;../../../msvc/build;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BZ_DEPS)/output-debug-x86/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -66,12 +68,14 @@
       <DataExecutionPrevention>
       </DataExecutionPrevention>
       <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalLibraryDirectories>$(BZ_DEPS)/output-debug-x86/lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>../../../include/;../../../win32/vc71;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BZ_DEPS)/output-release-x86/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -88,12 +92,13 @@
       <DataExecutionPrevention>
       </DataExecutionPrevention>
       <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalLibraryDirectories>$(BZ_DEPS)/output-release-x86/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\modeltool.cxx" />
     <ClCompile Include="..\Q3BSP.cxx" />
-    <ClCompile Include="..\..\..\src\common\TextUtils.cxx" />
     <ClCompile Include="..\wavefrontOBJ.cxx" />
   </ItemGroup>
   <ItemGroup>
@@ -103,12 +108,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\MSVC\build\regex.vcxproj">
-      <Project>{6dd493f8-31e1-4958-a240-d157affcb07e}</Project>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/tools/modeltool/Makefile.am
+++ b/tools/modeltool/Makefile.am
@@ -17,6 +17,4 @@ AM_CXXFLAGS = $(CONF_CXXFLAGS)
 
 MAINTAINERCLEANFILES = \
 	Makefile.in
-
-LDADD = \
-	$(top_srcdir)/src/common/libCommon.la
+	

--- a/tools/modeltool/Q3BSP.cxx
+++ b/tools/modeltool/Q3BSP.cxx
@@ -23,7 +23,6 @@ http://www.gnu.org/copyleft/lesser.txt.
 -----------------------------------------------------------------------------
 */
 #include "Q3BSP.h"
-#include "TextUtils.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -357,7 +356,7 @@ bool Quake3Level::dumpToModel ( CModel &model )
 	if (mEntities)
 	{
 		std::string ents = (char*)mEntities;
-		std::vector<std::string> entList = TextUtils::tokenize(ents,std::string("\n"));
+		std::vector<std::string> entList = tokenize(ents,std::string("\n"));
 
 		CCustomObject	cObject;
 		bool hasPos = false;
@@ -390,13 +389,13 @@ bool Quake3Level::dumpToModel ( CModel &model )
 				if (inTag)
 				{
 					// parse it up
-					std::vector<std::string> nubs = TextUtils::tokenize(theLine,std::string(" "),0,true);
-					if ( TextUtils::tolower(nubs[0]) == "classname" )
+					std::vector<std::string> nubs = tokenize(theLine,std::string(" "),0,true);
+					if ( tolower(nubs[0]) == "classname" )
 					{
 						if (nubs.size()>1)
 							cObject.name = nubs[1];
 					}
-					else if ( TextUtils::tolower(nubs[0]) == "origin" )
+					else if ( tolower(nubs[0]) == "origin" )
 					{
 						hasPos = true;
 						float pos[3] ={0,0,0};
@@ -414,7 +413,7 @@ bool Quake3Level::dumpToModel ( CModel &model )
 						pos[2] *= globalScale;
 						pos[2] += globalShift[2];
 
-						std::string line = "position " + TextUtils::format("%f %f %f",pos[0],pos[1],pos[2]);
+						std::string line = "position " + format("%f %f %f",pos[0],pos[1],pos[2]);
 						cObject.params.push_back(line);
 					}
 					else

--- a/tools/modeltool/model.h
+++ b/tools/modeltool/model.h
@@ -10,6 +10,12 @@
 #include <vector>
 #include <map>
 
+std::string tolower(const std::string& s);
+std::string format(const char* fmt, ...);
+std::string replace_all(const std::string& in, const std::string& replaceMe, const std::string& withMe);
+std::vector<std::string> tokenize(const std::string& in, const std::string &delims, const int maxTokens = 0, const bool useQuotes = false);
+
+
 extern std::string texdir;
 extern std::string groupName;
 extern bool useMaterials;

--- a/tools/modeltool/modeltool.cxx
+++ b/tools/modeltool/modeltool.cxx
@@ -8,7 +8,7 @@
 //   g++ -o modeltool modeltool.cxx  -I../../include ../../src/common/libCommon.a
 //
 
-#include "common.h"
+//#include "common.h"
 
 /* system headers */
 #include <stdio.h>
@@ -16,13 +16,185 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <sstream>
+#include <vector>
+#include <stdarg.h>
 
 /* common headers */
-#include "TextUtils.h"
+/*#include "TextUtils.h"*/
 
 #include "model.h"
 #include "wavefrontOBJ.h"
 #include "Q3BSP.h"
+
+std::string tolower(const std::string& s)
+{
+	std::string trans = s;
+
+	for (std::string::iterator i = trans.begin(), end = trans.end(); i != end; ++i)
+		*i = ::tolower(*i);
+	return trans;
+}
+
+/** returns a string converted to uppercase
+*/
+ std::string toupper(const std::string& s)
+{
+	std::string trans = s;
+	for (std::string::iterator i = trans.begin(), end = trans.end(); i != end; ++i)
+		*i = ::toupper(*i);
+	return trans;
+}
+
+std::string vformat(const char* fmt, va_list args) {
+	const int fixedbs = 8192;
+	char buffer[fixedbs];
+	const int bs = vsnprintf(buffer, fixedbs, fmt, args) + 1;
+	if (bs > fixedbs) {
+		char *bufp = new char[bs];
+		vsnprintf(bufp, bs, fmt, args);
+		std::string ret = bufp;
+		delete[] bufp;
+		return ret;
+	}
+
+	return buffer;
+}
+
+// text functions needed
+std::string format(const char* fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	std::string result = vformat(fmt, args);
+	va_end(args);
+	return result;
+}
+
+std::string replace_all(const std::string& in, const std::string& replaceMe, const std::string& withMe)
+{
+	std::string::size_type beginPos = 0;
+	std::string::size_type endPos = 0;
+	std::ostringstream tempStream;
+
+	endPos = in.find(replaceMe);
+	if (endPos == std::string::npos)
+		return in; // can't find anything to replace
+	if (replaceMe.empty()) return in; // can't replace nothing with something -- can do reverse
+
+	while (endPos != std::string::npos) {
+		// push the  part up to
+		tempStream << in.substr(beginPos, endPos - beginPos);
+		tempStream << withMe;
+		beginPos = endPos + replaceMe.size();
+		endPos = in.find(replaceMe, beginPos);
+	}
+	tempStream << in.substr(beginPos);
+	return tempStream.str();
+}
+
+std::vector<std::string> tokenize(const std::string& in, const std::string &delims, const int maxTokens, const bool useQuotes) {
+	std::vector<std::string> tokens;
+	int numTokens = 0;
+	bool inQuote = false;
+
+	std::ostringstream currentToken;
+
+	const std::string::size_type len = in.size();
+	std::string::size_type pos = in.find_first_not_of(delims);
+
+	int currentChar = (pos == std::string::npos) ? -1 : in[pos];
+	bool enoughTokens = (maxTokens && (numTokens >= (maxTokens - 1)));
+
+	while (pos < len && pos != std::string::npos && !enoughTokens) {
+
+		// get next token
+		bool tokenDone = false;
+		bool foundSlash = false;
+
+		currentChar = (pos < len) ? in[pos] : -1;
+		while ((currentChar != -1) && !tokenDone) {
+
+			tokenDone = false;
+
+			if (delims.find(currentChar) != std::string::npos && !inQuote) { // currentChar is a delim
+				pos++;
+				break; // breaks out of inner while loop
+			}
+
+			if (!useQuotes) {
+				currentToken << char(currentChar);
+			}
+			else {
+
+				switch (currentChar) {
+				case '\\': // found a backslash
+					if (foundSlash) {
+						currentToken << char(currentChar);
+						foundSlash = false;
+					}
+					else {
+						foundSlash = true;
+					}
+					break;
+				case '\"': // found a quote
+					if (foundSlash) { // found \"
+						currentToken << char(currentChar);
+						foundSlash = false;
+					}
+					else { // found unescaped "
+						if (inQuote) { // exiting a quote
+									   // finish off current token
+							tokenDone = true;
+							inQuote = false;
+							//slurp off one additional delimeter if possible
+							if (pos + 1 < len &&
+								delims.find(in[pos + 1]) != std::string::npos) {
+								pos++;
+							}
+
+						}
+						else { // entering a quote
+							   // finish off current token
+							tokenDone = true;
+							inQuote = true;
+						}
+					}
+					break;
+				default:
+					if (foundSlash) { // don't care about slashes except for above cases
+						currentToken << '\\';
+						foundSlash = false;
+					}
+					currentToken << char(currentChar);
+					break;
+				}
+			}
+
+			pos++;
+			currentChar = (pos < len) ? in[pos] : -1;
+		} // end of getting a Token
+
+		if (currentToken.str().size() > 0) { // if the token is something add to list
+			tokens.push_back(currentToken.str());
+			currentToken.str("");
+			numTokens++;
+		}
+
+		enoughTokens = (maxTokens && (numTokens >= (maxTokens - 1)));
+		if ((pos < len) && (pos != std::string::npos)) {
+			pos = in.find_first_not_of(delims, pos);
+		}
+
+	} // end of getting all tokens -- either EOL or max tokens reached
+
+	if (enoughTokens && pos != std::string::npos) {
+		std::string lastToken = in.substr(pos);
+		if (lastToken.size() > 0)
+			tokens.push_back(lastToken);
+	}
+
+	return tokens;
+}
 
 // globals/
 const char VersionString[] = "ModelTool v1.7  (WaveFront OBJ/BZW to BZFlag BZW converter)";
@@ -266,7 +438,7 @@ int main(int argc, char* argv[])
 
 	for ( int i = 2; i < argc; i++) {
 		std::string command = argv[i];
-		command = TextUtils::tolower(command);
+		command = tolower(command);
 
 		if (command == "-yz") {
 			flipYZ = true;
@@ -373,11 +545,11 @@ int main(int argc, char* argv[])
 
 	CModel	model;
 
-	if ( TextUtils::tolower(extenstion) == "obj" )
+	if ( tolower(extenstion) == "obj" )
 	{
 		readOBJ(model,input);
 	}
-	else if ( TextUtils::tolower(extenstion) == "bsp" )
+	else if ( tolower(extenstion) == "bsp" )
 	{
 		Quake3Level	level;
 		level.loadFromFile(input.c_str());

--- a/tools/modeltool/wavefrontOBJ.cxx
+++ b/tools/modeltool/wavefrontOBJ.cxx
@@ -4,7 +4,8 @@
 //
 //
 
-#include "common.h"
+//#include "common.h"
+#include "model.h"
 
 /* system headers */
 #include <stdio.h>
@@ -14,7 +15,6 @@
 #include <map>
 
 /* common headers */
-#include "TextUtils.h"
 #include "wavefrontOBJ.h"
 
 static void underscoreBeforeNumbers(std::string& name)
@@ -52,9 +52,9 @@ static void readMTL ( CModel &model, std::string file )
 	std::string fileText = pData;
 	free(pData);
 
-	fileText = TextUtils::replace_all(fileText,std::string("\r"),std::string(""));
+	fileText = replace_all(fileText,std::string("\r"),std::string(""));
 
-	std::vector<std::string> lines = TextUtils::tokenize(fileText, lineTerminator);
+	std::vector<std::string> lines = tokenize(fileText, lineTerminator);
 
 	if ( lines.size() < 2 )
 		return;
@@ -68,20 +68,20 @@ static void readMTL ( CModel &model, std::string file )
 	{
 		// do a trim here
 
-		std::vector<std::string> lineParts = TextUtils::tokenize(*lineItr,std::string(" "));
+		std::vector<std::string> lineParts = tokenize(*lineItr,std::string(" "));
 
 		if (lineParts.size() > 1)
 		{
 			std::string tag = lineParts[0];
 			if (tag != "#")
 			{
-				if (TextUtils::tolower(tag) == "newmtl")
+				if (tolower(tag) == "newmtl")
 				{
 					matName = lineParts[1];
 					underscoreBeforeNumbers(matName);
 					model.materials[matName] = material;
 				}
-				if (TextUtils::tolower(tag) == "ka")
+				if (tolower(tag) == "ka")
 				{
 					if (lineParts.size() > 3)
 					{
@@ -90,7 +90,7 @@ static void readMTL ( CModel &model, std::string file )
 						model.materials[matName].ambient[2] = (float)atof(lineParts[3].c_str());
 					}
 				}
-				if (TextUtils::tolower(tag) == "kd")
+				if (tolower(tag) == "kd")
 				{
 					if (lineParts.size() > 3)
 					{
@@ -99,7 +99,7 @@ static void readMTL ( CModel &model, std::string file )
 						model.materials[matName].diffuse[2] = (float)atof(lineParts[3].c_str());
 					}
 				}
-				if (TextUtils::tolower(tag) == "d")
+				if (tolower(tag) == "d")
 				{
 					if (lineParts.size() > 1)
 					{
@@ -107,7 +107,7 @@ static void readMTL ( CModel &model, std::string file )
 						model.materials[matName].diffuse[3] = (float)atof(lineParts[1].c_str());
 					}
 				}
-				if (TextUtils::tolower(tag) == "ks")
+				if (tolower(tag) == "ks")
 				{
 					if (lineParts.size() > 3)
 					{
@@ -116,7 +116,7 @@ static void readMTL ( CModel &model, std::string file )
 						model.materials[matName].specular[2] = (float)atof(lineParts[3].c_str());
 					}
 				}
-				if (TextUtils::tolower(tag) == "ns")
+				if (tolower(tag) == "ns")
 				{
 					if (lineParts.size() > 1) {
 						float shine = (float)atof(lineParts[1].c_str());
@@ -130,7 +130,7 @@ static void readMTL ( CModel &model, std::string file )
 						model.materials[matName].shine = (shine * maxShineExponent * shineFactor);
 					}
 				}
-				if (TextUtils::tolower(tag) == "ke")
+				if (tolower(tag) == "ke")
 				{
 					if (lineParts.size() > 3)
 					{
@@ -139,7 +139,7 @@ static void readMTL ( CModel &model, std::string file )
 						model.materials[matName].emission[2] = (float)atof(lineParts[3].c_str());
 					}
 				}
-				if (TextUtils::tolower(tag) == "map_kd")
+				if (tolower(tag) == "map_kd")
 				{
 					if (lineParts.size() > 1)
 					{
@@ -194,9 +194,9 @@ void readOBJ ( CModel &model, std::string file )
 	std::string fileText = pData;
 	free(pData);
 
-	fileText = TextUtils::replace_all(fileText,std::string("\r"),std::string(""));
+	fileText = replace_all(fileText,std::string("\r"),std::string(""));
 
-	std::vector<std::string> lines = TextUtils::tokenize(fileText,lineTerminator);
+	std::vector<std::string> lines = tokenize(fileText,lineTerminator);
 
 	if ( lines.size() < 2 )
 		return;
@@ -218,15 +218,15 @@ void readOBJ ( CModel &model, std::string file )
 	{
 		// do a trim here
 
-		std::vector<std::string> lineParts = TextUtils::tokenize(*lineItr,std::string(" "));
+		std::vector<std::string> lineParts = tokenize(*lineItr,std::string(" "));
 
 		if (lineParts.size() > 1)
 		{
 			if (lineParts[0] != "#")
 			{
-				if (TextUtils::tolower(lineParts[0]) == "mtllib" && lineParts.size()>1)
+				if (tolower(lineParts[0]) == "mtllib" && lineParts.size()>1)
 					readMTL(model,baseFilePath+lineParts[1]);
-				else if (TextUtils::tolower(lineParts[0]) == "v" && lineParts.size()>3)
+				else if (tolower(lineParts[0]) == "v" && lineParts.size()>3)
 				{
 					CVertex vert;
 					vert.x = (float)atof(lineParts[1].c_str());
@@ -244,7 +244,7 @@ void readOBJ ( CModel &model, std::string file )
 					temp_verts.push_back(vert);
 					vCount++;
 				}
-				else if (TextUtils::tolower(lineParts[0]) == "vt" && lineParts.size()>2)
+				else if (tolower(lineParts[0]) == "vt" && lineParts.size()>2)
 				{
 					CTexCoord uv;
 					uv.u = (float)atof(lineParts[1].c_str());
@@ -252,7 +252,7 @@ void readOBJ ( CModel &model, std::string file )
 					temp_texCoords.push_back(uv);
 					tCount++;
 				}
-				else if (TextUtils::tolower(lineParts[0]) == "vn" && lineParts.size()>3)
+				else if (tolower(lineParts[0]) == "vn" && lineParts.size()>3)
 				{
 					CVertex vert;
 					vert.x = (float)atof(lineParts[1].c_str());
@@ -269,7 +269,7 @@ void readOBJ ( CModel &model, std::string file )
 					temp_normals.push_back(vert);
 					nCount++;
 				}
-				else if (TextUtils::tolower(lineParts[0]) == "g" && lineParts.size()>1)
+				else if (tolower(lineParts[0]) == "g" && lineParts.size()>1)
 				{
 					if ( mesh.valid())
 					{
@@ -283,12 +283,12 @@ void readOBJ ( CModel &model, std::string file )
 					mesh.clear();
 					mesh.name = lineParts[1];
 				}
-				else if (TextUtils::tolower(lineParts[0]) == "usemtl" && lineParts.size()>1)
+				else if (tolower(lineParts[0]) == "usemtl" && lineParts.size()>1)
 				{
 					currentMaterial = lineParts[1];
 					underscoreBeforeNumbers(currentMaterial);
 				}
-				else if (TextUtils::tolower(lineParts[0]) == "f" && lineParts.size()>3)
+				else if (tolower(lineParts[0]) == "f" && lineParts.size()>3)
 				{
 					CFace face;
 					face.material = currentMaterial;


### PR DESCRIPTION
Update VC project to 2015,
force it to use the deps regex
remove the need for files from common
Moved text utils that is uses into it's own code.
this makes model tool independent of bzflag in case it gets moved to a tools repo.