### PR TITLE
Better implementation of flag on death PR 64

### DIFF
--- a/include/PlayerInfo.h
+++ b/include/PlayerInfo.h
@@ -102,6 +102,7 @@ public:
   int	getFlag() const;
   void	setFlag(int flag);
   bool	isFlagTransitSafe();
+  double timeSinceLastFlagDrop();
   const char	*getClientVersion();
   void		setClientVersion(const char * c);
   void		getClientVersionNumbers(int& major, int& minor, int& revision);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -493,9 +493,10 @@ class BZF_API bz_PlayerDieEventData_V2 : public bz_PlayerDieEventData_V1
 {
 public:
 	bz_PlayerDieEventData_V2() : bz_PlayerDieEventData_V1()
+		, flagHeldWhenKilled(-1)
 	{}
 
-	bz_ApiString flagHeldWhenKilled;
+	int flagHeldWhenKilled;
 };
 
 class BZF_API bz_PlayerSpawnEventData_V1 : public bz_EventData

--- a/src/bzfs/GameKeeper.cxx
+++ b/src/bzfs/GameKeeper.cxx
@@ -48,6 +48,7 @@ GameKeeper::Player::Player(int _playerIndex,
 
   lastState.order  = 0;
   score.playerID = _playerIndex;
+  lastHeldFlagID = -1;
 }
 
 GameKeeper::Player::Player(int _playerIndex,
@@ -70,6 +71,7 @@ GameKeeper::Player::Player(int _playerIndex,
   score.playerID = _playerIndex;
 
   netHandler->setPlayer(&player, _playerIndex);
+  lastHeldFlagID = -1;
 }
 
 GameKeeper::Player::Player(int _playerIndex, bz_ServerSidePlayerHandler* handler)
@@ -88,6 +90,7 @@ GameKeeper::Player::Player(int _playerIndex, bz_ServerSidePlayerHandler* handler
 
   lastState.order  = 0;
   score.playerID = _playerIndex;
+  lastHeldFlagID = -1;
 }
 
 GameKeeper::Player::~Player()

--- a/src/bzfs/GameKeeper.h
+++ b/src/bzfs/GameKeeper.h
@@ -36,6 +36,7 @@
 #include "Authentication.h"
 #include "messages.h"
 #include "bzfsAPI.h"
+#include "FlagInfo.h"
 #include "ShotUpdate.h"
 
 class ShotInfo {
@@ -168,6 +169,8 @@ public:
     bool addWasDelayed;
     bool hadEnter;
     double addDelayStartTime;
+
+	int lastHeldFlagID;
 
   private:
     static Player*    playerList[PlayerSlot];

--- a/src/game/PlayerInfo.cxx
+++ b/src/game/PlayerInfo.cxx
@@ -396,6 +396,10 @@ bool PlayerInfo::isFlagTransitSafe() {
   return now - lastFlagDropTime >= 2.0f;
 }
 
+double PlayerInfo::timeSinceLastFlagDrop() {
+	return now - lastFlagDropTime;
+}
+
 const char *PlayerInfo::getClientVersion() {
   return clientVersion;
 }


### PR DESCRIPTION
Since the client drops the flag before death, we can track the last used flag and see if it's landed yet, if not it was held a very short time before death and probably the one they were killed with.

This allows the API for flag on death to be created before 2.6.
Once the protocol is fixed, this will continue to work and the last held flag can be removed if it isn't needed by anything else. 

@allejo should validate that this solves his issues.