### PR TITLE
split windows .rc files into version and application files

### DIFF
--- a/MSVC/Version.rc
+++ b/MSVC/Version.rc
@@ -14,8 +14,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,4,9,0
- PRODUCTVERSION 2,4,9,0
+ FILEVERSION 2,4,11,0
+ PRODUCTVERSION 2,4,11,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -32,12 +32,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Tim Riker"
             VALUE "FileDescription", "BZFlag"
-            VALUE "FileVersion", "2.4.9.0"
+            VALUE "FileVersion", "2.4.11.0"
             VALUE "InternalName", "version.rc"
             VALUE "LegalCopyright", "Copyright (c) 1993-2016 Tim Riker"
             VALUE "OriginalFilename", "version.rc"
             VALUE "ProductName", "BZFlag"
-            VALUE "ProductVersion", "2.4.9.0"
+            VALUE "ProductVersion", "2.4.11.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/MSVC/Version.rc
+++ b/MSVC/Version.rc
@@ -1,0 +1,63 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 2,4,9,0
+ PRODUCTVERSION 2,4,9,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x0L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "Tim Riker"
+            VALUE "FileDescription", "BZFlag"
+            VALUE "FileVersion", "2.4.9.0"
+            VALUE "InternalName", "version.rc"
+            VALUE "LegalCopyright", "Copyright (c) 1993-2016 Tim Riker"
+            VALUE "OriginalFilename", "version.rc"
+            VALUE "ProductName", "BZFlag"
+            VALUE "ProductVersion", "2.4.9.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 1 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/MSVC/build/bzadmin.vcxproj
+++ b/MSVC/build/bzadmin.vcxproj
@@ -448,6 +448,9 @@ copy "$(BZ_DEPS)\output-$(Configuration)-$(PlatformShortName)\bin\*.dll" "..\..\
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\Version.rc" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/MSVC/build/bzadmin.vcxproj.filters
+++ b/MSVC/build/bzadmin.vcxproj.filters
@@ -74,5 +74,13 @@
     <Filter Include="Source Files">
       <UniqueIdentifier>{112bd0f4-fd72-4cbb-92e8-5477a03d25c7}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Resrouce Files">
+      <UniqueIdentifier>{29ced2be-c154-440f-92fc-cde45b60412b}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\Version.rc">
+      <Filter>Resrouce Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/MSVC/build/bzflag.vcxproj
+++ b/MSVC/build/bzflag.vcxproj
@@ -902,6 +902,7 @@ copy "$(BZ_DEPS)\output-$(Configuration)-$(PlatformShortName)\bin\*.dll" "..\..\
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
+    <ResourceCompile Include="..\Version.rc" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\bzflag\defaultBZDB.h" />

--- a/MSVC/build/bzflag.vcxproj.filters
+++ b/MSVC/build/bzflag.vcxproj.filters
@@ -558,5 +558,8 @@
     <ResourceCompile Include="..\bzflag.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
+    <ResourceCompile Include="..\Version.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/MSVC/build/bzfs.vcxproj
+++ b/MSVC/build/bzfs.vcxproj
@@ -730,6 +730,9 @@ copy "$(BZ_DEPS)\output-$(Configuration)-$(PlatformShortName)\bin\*.dll" "..\..\
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\Version.rc" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/MSVC/build/bzfs.vcxproj.filters
+++ b/MSVC/build/bzfs.vcxproj.filters
@@ -410,5 +410,13 @@
     <Filter Include="Source Files\Access Control">
       <UniqueIdentifier>{85afc332-e418-4b42-a6ca-bc5a25f490ef}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{bf3a26d4-3de5-453b-9141-57c134e83e23}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\Version.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/MSVC/bzflag.rc
+++ b/MSVC/bzflag.rc
@@ -41,54 +41,13 @@ END
 
 #endif    // APSTUDIO_INVOKED
 
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// Version
-//
-
-VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,4,11,0
- PRODUCTVERSION 2,4,11,0
- FILEFLAGSMASK 0x3fL
-#ifdef _DEBUG
- FILEFLAGS 0x1L
-#else
- FILEFLAGS 0x0L
 #endif
- FILEOS 0x40004L
- FILETYPE 0x0L
- FILESUBTYPE 0x0L
-BEGIN
-    BLOCK "StringFileInfo"
-    BEGIN
-        BLOCK "040904b0"
-        BEGIN
-            VALUE "CompanyName", "Tim Riker"
-            VALUE "FileDescription", "The BZFlag Client"
-            VALUE "FileVersion", "2.4.11.0"
-            VALUE "InternalName", "bzflag.rc"
-            VALUE "LegalCopyright", "Copyright (c) 1993-2017 Tim Riker"
-            VALUE "OriginalFilename", "bzflag.rc"
-            VALUE "ProductName", "BZFlag"
-            VALUE "ProductVersion", "2.4.11.0"
-        END
-    END
-    BLOCK "VarFileInfo"
-    BEGIN
-        VALUE "Translation", 0x409, 1200
-    END
-END
-
-#endif    // English (United States) resources
-/////////////////////////////////////////////////////////////////////////////
-
 
 
 #ifndef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
 //
-// Generated from the TEXTINCLUDE 3 resource.
+// Generated from the TEXTINCLUDE 2 resource.
 //
 
 


### PR DESCRIPTION
This gives all the exe projects a version resource so they have the correct version in details.
But only the client gets the icon as part of bzflag.rc