### PR TITLE
Fix for Issue #36

### DIFF
--- a/src/bzflag/LocalPlayer.cxx
+++ b/src/bzflag/LocalPlayer.cxx
@@ -111,12 +111,14 @@ void			LocalPlayer::doUpdate(float dt)
       }
     }
 
-    // if we've been paused for a long time, drop our flag
+    // if we've been paused for a long time, drop our good flag
+    FlagType* flag = getFlag();
     if (!wasPaused) {
       pauseTime = TimeKeeper::getTick();
       wasPaused = true;
     }
-    if (TimeKeeper::getTick() -  pauseTime > BZDB.eval(StateDatabase::BZDB_PAUSEDROPTIME)) {
+    if (flag != Flags::Null && flag->endurance != FlagSticky &&
+        TimeKeeper::getTick() -  pauseTime > BZDB.eval(StateDatabase::BZDB_PAUSEDROPTIME)) {
       server->sendDropFlag(getPosition());
       setStatus(getStatus() & ~PlayerState::FlagActive);
       pauseTime = TimeKeeper::getSunExplodeTime();

--- a/src/bzflag/LocalPlayer.cxx
+++ b/src/bzflag/LocalPlayer.cxx
@@ -98,6 +98,8 @@ void			LocalPlayer::doUpdate(float dt)
 {
   const bool hadShotActive = anyShotActive;
   const int numShots = World::getWorld()->getMaxShots();
+  static TimeKeeper pauseTime = TimeKeeper::getNullTime();
+  static bool wasPaused = false;
 
   // if paused then boost the reload times by dt (so that, effectively,
   // reloading isn't performed)
@@ -108,6 +110,21 @@ void			LocalPlayer::doUpdate(float dt)
 	shots[i]->boostReloadTime(dt);
       }
     }
+
+    // if we've been paused for a long time, drop our flag
+    if (!wasPaused) {
+      pauseTime = TimeKeeper::getTick();
+      wasPaused = true;
+    }
+    if (TimeKeeper::getTick() -  pauseTime > BZDB.eval(StateDatabase::BZDB_PAUSEDROPTIME)) {
+      server->sendDropFlag(getPosition());
+      setStatus(getStatus() & ~PlayerState::FlagActive);
+      pauseTime = TimeKeeper::getSunExplodeTime();
+    }
+
+  } else {
+    pauseTime = TimeKeeper::getNullTime();
+    wasPaused = false;
   }
 
   // reap dead (reloaded) shots
@@ -131,13 +148,14 @@ void			LocalPlayer::doUpdate(float dt)
   if (!anyShotActive && hadShotActive)
     target = NULL;
 
-  // Update bad flag shaking time
+  // drop bad flag if timeout has expired
   if (!isPaused() && dt > 0.0f && World::getWorld()->allowShakeTimeout() &&
       getFlag() != Flags::Null && getFlag()->endurance == FlagSticky &&
       flagShakingTime > 0.0f) {
     flagShakingTime -= dt;
     if (flagShakingTime <= 0.0f) {
       flagShakingTime = 0.0f;
+      server->sendDropFlag(getPosition());
     }
   }
 }

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -6350,11 +6350,7 @@ static void		updatePauseCountdown(float dt)
 	hud->setAlert(1, "Can't pause when you are in the phantom zone", 1.0f, false);
 
       } else {
-	// okay, now we pause.  first drop any team flag we may have.
-	const FlagType* flagd = myTank->getFlag();
-	if (flagd->flagTeam != NoTeam)
-	  serverLink->sendDropFlag(myTank->getPosition());
-
+	// okay, now we prepare to pause
 	if (World::getWorld()->allowRabbit() && (myTank->getTeam() == RabbitTeam))
 	  serverLink->sendNewRabbit();
 

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -6350,7 +6350,11 @@ static void		updatePauseCountdown(float dt)
 	hud->setAlert(1, "Can't pause when you are in the phantom zone", 1.0f, false);
 
       } else {
-	// okay, now we prepare to pause
+	// okay, now we pause.  first drop any team flag we may have.
+	const FlagType* flagd = myTank->getFlag();
+	if (flagd->flagTeam != NoTeam)
+	  serverLink->sendDropFlag(myTank->getPosition());
+
 	if (World::getWorld()->allowRabbit() && (myTank->getTeam() == RabbitTeam))
 	  serverLink->sendNewRabbit();
 

--- a/src/game/PlayerInfo.cxx
+++ b/src/game/PlayerInfo.cxx
@@ -479,7 +479,7 @@ bool PlayerInfo::hasStartedToNotRespond() {
   const float notRespondingTime =
     BZDB.eval(StateDatabase::BZDB_NOTRESPONDINGTIME);
   bool startingToNotRespond = false;
-  if (state > PlayerInLimbo) {
+  if (state > PlayerInLimbo && !paused) {
     bool oldnr = notResponding;
     notResponding = (now - lastupdate) > notRespondingTime;
     if (!oldnr && notResponding) {


### PR DESCRIPTION
It turns out that BZFlag dropping flags while paused is broken. It never worked correctly because paused players do not send updates, so the server drops our flag for not responding after five seconds regardless of BZDB_PAUSEDROPTIME. Further, the client didn't check if the flag was bad when initiating a drop (only happens when BZDB_PAUSEDROPTIME < 5 seconds). 

This pull fixes _pauseDropTime by not counting paused players as not responding for failing to send updates within the five-second window. 

This pull modifies the client not to send flag drops for sticky flags while paused. 

As a result, a sticky flag can be held indefinitely by paused player. You might want to consider if a paused player should send updates, and if players can be simultaneously paused and not responding. The current implementation (before this change) does not distinguished pause responsive from paused not responding. 