### PR TITLE
Add Travis to test builds on macOS + Linux

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,8 @@ indent_style = space
 indent_size = 2
 tab_width = 8
 
-[*.md,*.markdown]
+[*.{md,markdown}]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ sudo: false
 dist: trusty
 language: cpp
 
-os:
-  - linux
-  - osx
-
 env:
   - HOMEBREW_NO_AUTO_UPDATE=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,7 @@ before_install:
    - eval "${MATRIX_EVAL}"
 
 script:
-  - ./autogen.sh -v
-  - ./configure
-  - if [[ "$XCODE_BUILD" == 1 ]]; then xcodebuild build -scheme BZFlag -configuration Debug -project Xcode/BZFlag.xcodeproj; else make; fi
-  - if [[ "$XCODE_BUILD" != 1 ]]; then make check; fi
+  - if [[ "$XCODE_BUILD" == 1 ]]; then xcodebuild build -scheme BZFlag -configuration Debug -project Xcode/BZFlag.xcodeproj; else ./autogen.sh -v && ./configure --enable-debug && make && make check; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+sudo: false
+dist: trusty
+language: cpp
+
+os:
+  - linux
+  - osx
+
+env:
+  - HOMEBREW_NO_AUTO_UPDATE=1
+
+addons:
+  apt:
+    packages:
+      - libtool
+      - automake
+      - autoconf
+      - libgl1-mesa-dev
+      - libglu1-mesa-dev
+      - libsdl1.2-dev
+      - libsdl-sound1.2-dev
+      - libc-ares-dev
+      - zlib1g-dev
+      - make
+
+      # Resolved virtual packages
+      - libcurl4-openssl-dev # libcurl3-dev
+      - libncurses-dev # libncurses5-dev
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install autoconf automake libtool c-ares sdl2; fi
+
+script:
+  - ./autogen.sh -v
+  - ./configure
+  - make
+  - make check
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 
 addons:
   apt:
-    packages:
+    packages: &linux_deps
       - libtool
       - automake
       - autoconf
@@ -27,14 +27,45 @@ addons:
       - libcurl4-openssl-dev # libcurl3-dev
       - libncurses-dev # libncurses5-dev
 
-install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install autoconf automake libtool c-ares sdl2; fi
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *linux_deps
+            - [ g++-4.6 ]
+      env:
+        - MATRIX_EVAL="CC=gcc-4.6 && CXX=g++-4.6"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *linux_deps
+            - [ g++-7 ]
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: osx
+      env:
+        - MATRIX_EVAL="brew install autoconf automake libtool c-ares sdl2 gcc && CC=gcc-7 && CXX=g++-7"
+
+    - os: osx
+      env:
+        - MATRIX_EVAL="brew install autoconf automake libtool c-ares sdl2 && XCODE_BUILD=1"
+
+before_install:
+   - eval "${MATRIX_EVAL}"
 
 script:
   - ./autogen.sh -v
   - ./configure
-  - make
-  - make check
+  - if [[ "$XCODE_BUILD" == 1 ]]; then xcodebuild build -scheme BZFlag -configuration Debug -project Xcode/BZFlag.xcodeproj; else make; fi
+  - if [[ "$XCODE_BUILD" != 1 ]]; then make check; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,11 @@ matrix:
 
     - os: osx
       env:
-        - MATRIX_EVAL="brew install autoconf automake libtool c-ares sdl2 gcc && CC=gcc-7 && CXX=g++-7"
+        - MATRIX_EVAL="brew install c-ares sdl2"
 
     - os: osx
       env:
-        - MATRIX_EVAL="brew install autoconf automake libtool c-ares sdl2 && XCODE_BUILD=1"
+        - MATRIX_EVAL="brew install c-ares sdl2 && XCODE_BUILD=1"
 
 before_install:
    - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - *linux_deps
-            - [ g++-4.6 ]
+            - [ g++-4.8 ]
       env:
-        - MATRIX_EVAL="CC=gcc-4.6 && CXX=g++-4.6"
+        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
     - os: linux
       addons:
         apt:

--- a/Xcode/BZFlag.xcodeproj/xcshareddata/xcschemes/BZFlag.xcscheme
+++ b/Xcode/BZFlag.xcodeproj/xcshareddata/xcschemes/BZFlag.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03C8EE24167ABE2300BB07A5"
+               BuildableName = "BZFlag.app"
+               BlueprintName = "BZFlag"
+               ReferencedContainer = "container:BZFlag.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03C8EE24167ABE2300BB07A5"
+            BuildableName = "BZFlag.app"
+            BlueprintName = "BZFlag"
+            ReferencedContainer = "container:BZFlag.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03C8EE24167ABE2300BB07A5"
+            BuildableName = "BZFlag.app"
+            BlueprintName = "BZFlag"
+            ReferencedContainer = "container:BZFlag.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03C8EE24167ABE2300BB07A5"
+            BuildableName = "BZFlag.app"
+            BlueprintName = "BZFlag"
+            ReferencedContainer = "container:BZFlag.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Regarding earlier discussions, adding simple Travis tests to make sure things continue to build after commits on both Linux and macOS.

As an example: https://travis-ci.org/allejo/bzflag/builds/285422595

Currently, can't run `./configure` with the `--enable-debug` flag since it'll treat warnings as errors; this affects both Linux and macOS, see here:

- https://travis-ci.org/allejo/bzflag/jobs/285413694#L1687

Additionally, should we add IRC notifications? If so, how's BZnotify configured/what endpoint should we point to?