### PR TITLE
Add string trimming functions to API + TextUtils

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 BZFlag 2.4.11
 -------------
 
+* Add string utility functions to the API and TextUtils - Vladimir Jimenez
 * Fixed an issue with ASCII characters from modified non-ASCII keys in SDL 2
     - Joshua Bodine
 * Fixed compilation on macOS when using autotools/gcc - Mike Miller

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 BZFlag 2.4.11
 -------------
 
+* Add new functions to the bz_APIStringList - Vladimir Jimenez
 * Add string utility functions to the API and TextUtils - Vladimir Jimenez
 * Fixed an issue with ASCII characters from modified non-ASCII keys in SDL 2
     - Joshua Bodine

--- a/include/TextUtils.h
+++ b/include/TextUtils.h
@@ -60,6 +60,9 @@ namespace TextUtils {
 
   inline std::string ltrim(const std::string& s, const char* trim = " ")
   {
+    if (!trim)
+      return s;
+
     size_t pos = s.find_first_not_of(trim);
 
     if (pos == std::string::npos)
@@ -70,6 +73,9 @@ namespace TextUtils {
 
   inline std::string rtrim(const std::string& s, const char* trim = " ")
   {
+    if (!trim)
+      return s;
+
     size_t pos = s.find_last_not_of(trim);
 
     if (pos == std::string::npos)

--- a/include/TextUtils.h
+++ b/include/TextUtils.h
@@ -58,6 +58,31 @@ namespace TextUtils {
     return trans;
   }
 
+  inline std::string ltrim(const std::string& s, const char* trim = " ")
+  {
+    size_t pos = s.find_first_not_of(trim);
+
+    if (pos == std::string::npos)
+      return s;
+
+    return s.substr(pos, s.length() + 1);
+  }
+
+  inline std::string rtrim(const std::string& s, const char* trim = " ")
+  {
+    size_t pos = s.find_last_not_of(trim);
+
+    if (pos == std::string::npos)
+      return s;
+
+    return s.substr(0, pos + 1);
+  }
+
+  inline std::string trim(const std::string& s, const char* trim = " ")
+  {
+    return (rtrim(ltrim(s, trim), trim));
+  }
+
   /** replace all of in in replaceMe with withMe
    */
   std::string replace_all(const std::string& in, const std::string& replaceMe, const std::string& withMe);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -223,6 +223,9 @@ public:
   bz_APIStringList& operator=( const bz_APIStringList& r );
   bz_APIStringList& operator=( const std::vector<std::string>& r );
 
+  const char* join(const char* delimiter = ",");
+  bool contains(const std::string &needle);
+
   unsigned int size ( void ) const;
   void clear ( void );
 

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1945,6 +1945,10 @@ BZF_API bool bz_stopRecBuf( void );
 BZF_API const char *bz_format(const char* fmt, ...);
 BZF_API const char *bz_toupper(const char* val );
 BZF_API const char *bz_tolower(const char* val );
+BZF_API const char *bz_rtrim(const char* val, const char* trim = " ");
+BZF_API const char *bz_ltrim(const char* val, const char* trim = " ");
+BZF_API const char *bz_trim(const char* val, const char* trim = " ");
+BZF_API const char* bz_join(bz_APIStringList* list, const char* delimiter = ",");
 BZF_API const char *bz_urlEncode(const char* val );
 
 // game countdown

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1951,7 +1951,7 @@ BZF_API const char *bz_tolower(const char* val );
 BZF_API const char *bz_rtrim(const char* val, const char* trim = " ");
 BZF_API const char *bz_ltrim(const char* val, const char* trim = " ");
 BZF_API const char *bz_trim(const char* val, const char* trim = " ");
-BZF_API const char* bz_join(bz_APIStringList* list, const char* delimiter = ",");
+BZF_API const char *bz_join(bz_APIStringList* list, const char* delimiter = ",");
 BZF_API const char *bz_urlEncode(const char* val );
 
 // game countdown

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -4004,6 +4004,9 @@ BZF_API const char* bz_join(bz_APIStringList* list, const char* delimiter)
   if (!list)
     return NULL;
 
+  if (!delimiter)
+    delimiter = "";
+
   std::string joined = "";
 
   for (unsigned int i = 0; i < list->size(); i++) {

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -600,6 +600,16 @@ bz_APIStringList& bz_APIStringList::operator=( const std::vector<std::string>& r
   return *this;
 }
 
+const char* bz_APIStringList::join(const char* delimiter)
+{
+  return bz_join(this, delimiter);
+}
+
+bool bz_APIStringList::contains(const std::string &needle)
+{
+  return (std::find(data->list.begin(), data->list.end(), needle) != data->list.end());
+}
+
 unsigned int bz_APIStringList::size ( void ) const
 {
   return data->list.size();

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -3965,6 +3965,47 @@ BZF_API const char *bz_tolower(const char* val )
   return temp.c_str();
 }
 
+BZF_API const char* bz_ltrim(const char* val, const char* trim)
+{
+  if (!val)
+    return NULL;
+
+  return TextUtils::ltrim(std::string(val), trim).c_str();
+}
+
+BZF_API const char* bz_rtrim(const char* val, const char* trim)
+{
+  if (!val)
+    return NULL;
+
+  return TextUtils::rtrim(std::string(val), trim).c_str();
+}
+
+BZF_API const char* bz_trim(const char* val, const char* trim)
+{
+  if (!val)
+    return NULL;
+
+  return TextUtils::trim(std::string(val), trim).c_str();
+}
+
+BZF_API const char* bz_join(bz_APIStringList* list, const char* delimiter)
+{
+  if (!list)
+    return NULL;
+
+  std::string joined = "";
+
+  for (unsigned int i = 0; i < list->size(); i++) {
+    joined += list->get(i);
+
+    if (i != (list->size() - 1))
+      joined += delimiter;
+  }
+
+  return joined.c_str();
+}
+
 BZF_API const char *bz_urlEncode(const char* val )
 {
   static std::string temp;


### PR DESCRIPTION
New functions to TextUtils and create respective API functions

```cpp
const char* bz_rtrim(const char* val, const char* trim = " ");
const char* bz_ltrim(const char* val, const char* trim = " ");
const char* bz_trim(const char* val, const char* trim = " ");
const char* bz_join(bz_APIStringList* list, const char* delimiter = ",");
```

```cpp
const char* bz_APIStringList::join(const char* delimiter = ",");
bool bz_APIStringList::contains(const std::string &needle);
```