### PR TITLE
Allow API to trigger CTF capture event

### DIFF
--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1997,6 +1997,7 @@ int convertTeam( bz_eTeamType team );
 
 // game type info
 BZF_API bz_eGameType bz_getGameType ( void );
+BZF_API bool bz_triggerFlagCapture(int playerID, bz_eTeamType teamCapping, bz_eTeamType teamCapped);
 
 
 typedef struct {

--- a/src/bzfs/bzfs.h
+++ b/src/bzfs/bzfs.h
@@ -162,6 +162,8 @@ extern Shots::Manager	ShotManager;
 
 extern VotingArbiter	*votingarbiter;
 
+bool captureFlag(int playerIndex, TeamColor teamCaptured, TeamColor teamCapped = NoTeam, bool checkCheat = true);
+
 void resetTeamScores(void);
 void pauseCountdown(int pausedBy = ServerPlayer);
 void resumeCountdown(int resumedBy = ServerPlayer);

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -4300,6 +4300,14 @@ BZF_API	bz_eGameType bz_getGameType ( void )
   return eFFAGame;
 }
 
+BZF_API bool bz_triggerFlagCapture(int playerID, bz_eTeamType teamCapping, bz_eTeamType teamCapped)
+{
+  if (bz_getGameType() != eCTFGame)
+    return false;
+
+  return captureFlag(playerID, (TeamColor)convertTeam(teamCapping), (TeamColor)convertTeam(teamCapped), false);
+}
+
 
 // utility
 BZF_API const char* bz_MD5 ( const char * str )


### PR DESCRIPTION
For custom game modes that use the CTF scoring system, then having the API allow to trigger CTF capture events sure beats manually killing all the players manually and modifying the team scores individually.

An example of a plugin that'd benefit this would be my "All Hands on Deck" plug-in.