### PR TITLE
Fix World Weapon API and functionality

### DIFF
--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -328,6 +328,7 @@ typedef enum
   bz_eAutoPilotEvent,
   bz_eMuteEvent,
   bz_eUnmuteEvent,
+  bz_eServerShotFiredEvent,
   bz_eLastEvent    //this is never used as an event, just show it's the last one
 } bz_eEventType;
 
@@ -1019,6 +1020,25 @@ public:
   bz_ApiString type;
   int playerID;
   int shotID;
+};
+
+class BZF_API bz_ServerShotFiredEventData_V1 : public bz_EventData
+{
+public:
+  bz_ServerShotFiredEventData_V1() : bz_EventData(bz_eServerShotFiredEvent)
+    , guid(0)
+    , lifetime(0)
+    , team(eRogueTeam)
+  {
+    pos[0] = pos[1] = pos[2] = 0.0f;
+  }
+
+  uint32_t guid;
+  bz_ApiString flagType;
+  float lifetime;
+  float pos[3];
+  float lookAt[3];
+  bz_eTeamType team;
 };
 
 class BZF_API bz_PlayerUpdateEventData_V1 : public bz_EventData

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -418,7 +418,6 @@ typedef enum
 #define BZ_ALLUSERS		-1
 #define BZ_NULLUSER		-3
 
-// 253 is reserved for the SERVER player
 #define BZ_PUBLICCHAT		254
 #define BZ_ADMINCHAT		252
 #define BZ_ROGUECHAT		251
@@ -430,6 +429,7 @@ typedef enum
 #define BZ_RABBITCHAT		245
 #define BZ_HUNTERCHAT		244
 
+#define BZ_SERVERPLAYER		253
 #define BZ_LASTREALPLAYER	243
 
 #define BZ_BZDBPERM_NA		0

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1638,6 +1638,8 @@ DEPRECATED BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, floa
 BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float lookAtVector[3], bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
 BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float tilt, float direction, bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
 
+BZF_API bool bz_endServerShot(uint32_t shotGUID);
+
 BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name);
 BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value);
 BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1630,10 +1630,10 @@ BZF_API bool bz_sendTextMessagef(int from, bz_eTeamType to, const char* fmt, ...
 BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL );
 
 // world weapons
-BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam = eRogueTeam);
+DEPRECATED BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+DEPRECATED BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+DEPRECATED BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+DEPRECATED BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam = eRogueTeam);
 
 BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name);
 BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1630,23 +1630,23 @@ BZF_API bool bz_sendTextMessagef(int from, bz_eTeamType to, const char* fmt, ...
 BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL );
 
 // world weapons
-// deprecated API, will be removed in next version
-BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam = eRogueTeam);
+// will be removed in next breaking version after 2.4.x
+/*DEPRECATED*/ BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+/*DEPRECATED*/ BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+/*DEPRECATED*/ BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+/*DEPRECATED*/ BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam = eRogueTeam);
 
 // new server shot API
 BZF_API uint32_t bz_fireServerShot(const char* shotType, float origin[3], float vector[3], bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
 
-// deprecated API, will be remvoed in next version
-BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name);
-BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value);
-BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name);
+// will be removed in next breaking version after 2.4.x
+/*DEPRECATED*/ BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name);
+/*DEPRECATED*/ BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value);
+/*DEPRECATED*/ BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name);
 
 // new shot metadata API
 BZF_API void bz_setShotMetaData (const uint32_t shotGUID, const char* name, uint32_t value);
-BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, const char* value);
+BZF_API void bz_setShotMetaData (const uint32_t shotGUID, const char* name, const char* value);
 BZF_API bool bz_shotHasMetaData (const uint32_t shotGUID, const char* name);
 
 BZF_API uint32_t bz_getShotMetaDataI(const uint32_t shotGUID, const char* name);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1639,6 +1639,12 @@ BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, flo
 // new server shot API
 BZF_API uint32_t bz_fireServerShot(const char* shotType, float origin[3], float vector[3], bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
 
+// deprecated API, will be remvoed in next version
+BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name);
+BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value);
+BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name);
+
+// new shot metadata API
 BZF_API void bz_setShotMetaData (const uint32_t shotGUID, const char* name, uint32_t value);
 BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, const char* value);
 BZF_API bool bz_shotHasMetaData (const uint32_t shotGUID, const char* name);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1037,7 +1037,7 @@ public:
   bz_ApiString flagType;
   float lifetime;
   float pos[3];
-  float lookAt[3];
+  float velocity[3];
   bz_eTeamType team;
 };
 
@@ -1630,23 +1630,27 @@ BZF_API bool bz_sendTextMessagef(int from, bz_eTeamType to, const char* fmt, ...
 BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL );
 
 // world weapons
-DEPRECATED BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-DEPRECATED BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-DEPRECATED BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-DEPRECATED BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam = eRogueTeam);
+// deprecated API, will be removed in next version
+BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam = eRogueTeam);
 
-BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float lookAtVector[3], bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
-BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float tilt, float direction, bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
+// new server shot API
+BZF_API uint32_t bz_fireServerShot(const char* shotType, float origin[3], float vector[3], bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
 
-BZF_API const bz_ApiString bz_getShotMetaData(const uint32_t shotGUID, const char* name);
-BZF_API bool bz_hasShotMetaData(const uint32_t shotGUID, const char* name);
+BZF_API void bz_setShotMetaData (const uint32_t shotGUID, const char* name, uint32_t value);
 BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, const char* value);
+BZF_API bool bz_shotHasMetaData (const uint32_t shotGUID, const char* name);
 
-BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name);
-BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value);
-BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name);
+BZF_API uint32_t bz_getShotMetaDataI(const uint32_t shotGUID, const char* name);
+BZF_API const char* bz_getShotMetaDataS(const uint32_t shotGUID, const char* name);
 
 BZF_API uint32_t bz_getShotGUID (int fromPlayer, int shotID);
+
+// geometry utils
+BZF_API bool bz_vectorFromPoints(const float p1[3], const float p2[3], float outVec[3]);
+BZF_API bool bz_vectorFromRotations(const float tilt, const float rotation, float outVec[3]);
 
 typedef struct {
   int year;

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1638,8 +1638,6 @@ DEPRECATED BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, floa
 BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float lookAtVector[3], bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
 BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float tilt, float direction, bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
 
-BZF_API bool bz_endServerShot(uint32_t shotGUID);
-
 BZF_API const bz_ApiString bz_getShotMetaData(const uint32_t shotGUID, const char* name);
 BZF_API bool bz_hasShotMetaData(const uint32_t shotGUID, const char* name);
 BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, const char* value);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1635,6 +1635,9 @@ DEPRECATED BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, i
 DEPRECATED BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
 DEPRECATED BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam = eRogueTeam);
 
+BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float lookAtVector[3], bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
+BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float tilt, float direction, bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
+
 BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name);
 BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value);
 BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1640,6 +1640,10 @@ BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float o
 
 BZF_API bool bz_endServerShot(uint32_t shotGUID);
 
+BZF_API const bz_ApiString bz_getShotMetaData(const uint32_t shotGUID, const char* name);
+BZF_API bool bz_hasShotMetaData(const uint32_t shotGUID, const char* name);
+BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, const char* value);
+
 BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name);
 BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value);
 BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -43,6 +43,18 @@
 #define BZF_PLUGIN_CALL extern "C"
 #endif
 
+/* Provide a means to deprecate API functions to discourage their use
+ * in the future
+ */
+#ifdef __GNUC__
+#  define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#  define DEPRECATED __declspec(deprecated)
+#else
+#  pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+#  define DEPRECATED
+#endif
+
 class bz_Plugin;
 
 #define BZ_API_VERSION	26

--- a/plugins/rabidRabbit/rabidRabbit.cpp
+++ b/plugins/rabidRabbit/rabidRabbit.cpp
@@ -170,13 +170,9 @@ void RabidRabbitEventHandler::Event(bz_EventData *eventData)
 
   for (unsigned int i = 0; i < zoneList.size(); i++) {
     if (!zoneList[i].WWFired && currentKillZone == i) {
-      bz_fireWorldWep(zoneList[i].WW.c_str(),
-		      zoneList[i].WWLifetime,
-		      BZ_SERVER,zoneList[i].WWPosition,
-		      zoneList[i].WWTilt,
-		      zoneList[i].WWDirection,
-		      zoneList[i].WWShotID,
-		      0);
+      float vector[3];
+      bz_vectorFromRotations(zoneList[i].WWTilt, zoneList[i].WWDirection, vector);
+      bz_fireServerShot(zoneList[i].WW.c_str(), zoneList[i].WWPosition, vector);
       zoneList[i].WWFired = true;
       zoneList[i].WWLastFired = bz_getCurrentTime();
     } else {

--- a/plugins/shockwaveDeath/shockwaveDeath.cpp
+++ b/plugins/shockwaveDeath/shockwaveDeath.cpp
@@ -31,16 +31,9 @@ void SWDeathHandler::Event ( bz_EventData *eventData )
   // Cast our event data so we can access the death position
   bz_PlayerDieEventData_V1 *dieData = (bz_PlayerDieEventData_V1*)eventData;
 
-  // Retrieve the current reload time value
-  float reloadTime = (float)bz_getBZDBDouble("_reloadTime");
-
-  // If _swDeathReloadFactor is defined and greater than zero, multiply the
-  // reload time by this factor
-  if (bz_BZDBItemExists("_swDeathReloadFactor") && bz_getBZDBDouble("_swDeathReloadFactor") > 0)
-    reloadTime *= (float)bz_getBZDBDouble("_swDeathReloadFactor");
-
   // Fire a shockwave where the player died
-  bz_fireWorldWep("SW", reloadTime, BZ_SERVER, dieData->state.pos, 0, 0, 0, 0.0f);
+  float vector[3] = {0, 0, 0};
+  bz_fireServerShot("SW", dieData->state.pos, vector);
 }
 
 // Local Variables: ***

--- a/plugins/wwzones/wwzones.cpp
+++ b/plugins/wwzones/wwzones.cpp
@@ -210,7 +210,9 @@ void WWZEventHandler::Event (bz_EventData *eventData)
       for (unsigned int i = 0; i < zoneList.size(); i++) {
 	if (zoneList[i].pointInZone(player->lastKnownState.pos) && player->spawned) {
 	  if (wasHere(i, player->playerID) && OKToFire(i, player->playerID) && !zoneList[i].zoneWeaponFired) {
-	    bz_fireWorldWep(zoneList[i].zoneWeapon.c_str(), zoneList[i].zoneWeaponLifetime, BZ_SERVER, zoneList[i].zoneWeaponPosition, zoneList[i].zoneWeaponTilt, zoneList[i].zoneWeaponDirection, zoneList[i].zoneWeaponShotID, 0);
+	    float vector[3];
+	    bz_vectorFromRotations(zoneList[i].zoneWeaponTilt, zoneList[i].zoneWeaponDirection, vector);
+	    bz_fireServerShot(zoneList[i].zoneWeapon.c_str(), zoneList[i].zoneWeaponPosition, vector);
 	    zoneList[i].zoneWeaponFired = true;
 	    zoneList[i].zoneWeaponLastFired = bz_getCurrentTime();
 	  } else {

--- a/src/bzfs/GameKeeper.cxx
+++ b/src/bzfs/GameKeeper.cxx
@@ -370,6 +370,25 @@ void GameKeeper::Player::setMaxShots(int _maxShots)
   maxShots = _maxShots;
 }
 
+float GetShotLifetime(FlagType* flagType)
+{
+	float lifeTime(BZDB.eval(StateDatabase::BZDB_RELOADTIME));
+	if (flagType == Flags::RapidFire)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_RFIREADLIFE);
+	else if (flagType == Flags::MachineGun)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_MGUNADLIFE);
+	else if (flagType == Flags::GuidedMissile)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_GMADLIFE) + .01f;
+	else if (flagType == Flags::Laser)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_LASERADLIFE);
+	else if (flagType == Flags::ShockWave)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_SHOCKADLIFE);
+	else if (flagType == Flags::Thief)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_THIEFADLIFE);
+
+	return lifeTime;
+}
+
 bool GameKeeper::Player::addShot(int id, int salt, FiringInfo &firingInfo)
 {
   float now((float)TimeKeeper::getCurrent().getSeconds());
@@ -388,19 +407,7 @@ bool GameKeeper::Player::addShot(int id, int salt, FiringInfo &firingInfo)
 
   shotsInfo.resize(maxShots);
 
-  float lifeTime(BZDB.eval(StateDatabase::BZDB_RELOADTIME));
-  if (firingInfo.flagType == Flags::RapidFire)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_RFIREADLIFE);
-  else if (firingInfo.flagType == Flags::MachineGun)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_MGUNADLIFE);
-  else if (firingInfo.flagType == Flags::GuidedMissile)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_GMADLIFE) + .01f;
-  else if (firingInfo.flagType == Flags::Laser)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_LASERADLIFE);
-  else if (firingInfo.flagType == Flags::ShockWave)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_SHOCKADLIFE);
-  else if (firingInfo.flagType == Flags::Thief)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_THIEFADLIFE);
+  float lifeTime = GetShotLifetime(firingInfo.flagType);
 
   ShotInfo myShot;
   myShot.firingInfo  = firingInfo;

--- a/src/bzfs/ShotManager.cxx
+++ b/src/bzfs/ShotManager.cxx
@@ -227,6 +227,37 @@ namespace Shots
 	{
 	}
 
+	void Shot::SetMetaData(const std::string& name, const char* data)
+	{
+		if (MetaData.find(name) == MetaData.end())
+			MetaData[name] = MetaDataItem();
+		MetaData[name].DataS = data;
+	}
+
+	void Shot::SetMetaData(const std::string& name, uint32_t data)
+	{
+		if (MetaData.find(name) == MetaData.end())
+			MetaData[name] = MetaDataItem();
+		MetaData[name].DataI = data;
+	}
+
+	bool Shot::HasMetaData(const std::string& name)
+	{
+		return MetaData.find(name) != MetaData.end();
+	}
+
+	const char * Shot::GetMetaDataS(const std::string& name)
+	{
+		auto itr = MetaData.find(name);
+		return itr == MetaData.end() ? nullptr : itr->second.DataS.c_str();
+	}
+
+	uint32_t Shot::GetMetaDataI(const std::string& name)
+	{
+		auto itr = MetaData.find(name);
+		return itr == MetaData.end() ? 0 : itr->second.DataI;
+	}
+
 	bool Shot::Update()
 	{
 		if (Logic.Update(*this))

--- a/src/bzfs/ShotManager.h
+++ b/src/bzfs/ShotManager.h
@@ -67,14 +67,22 @@ protected:
 	FlightLogic &Logic;
 
 	double	LifeTime;
+
+	class MetaDataItem
+	{
+	public:
+		std::string Name;
+		std::string DataS;
+		uint32_t	DataI;
+	};
+
+	std::map<std::string, MetaDataItem> MetaData;
+
 public:
 	fvec3		StartPosition;
 	fvec3		LastUpdatePosition;
 	double		LastUpdateTime;
 	double		StartTime;
-
-	std::map<std::string, std::string> stringMetaData;
-	std::map<std::string, uint32_t> intMetaData;
 
 	FiringInfo	Info;
 
@@ -103,6 +111,14 @@ public:
 	bool CollideBox ( fvec3 &center, fvec3 size, float rotation ) {return Logic.CollideBox(*this,center,size,rotation);}
 	bool CollideSphere ( fvec3 &center, float radius ) {return Logic.CollideSphere(*this,center,radius);}
 	bool CollideCylinder ( fvec3 &center, float height, float radius) {return Logic.CollideCylinder(*this,center,height,radius);}
+
+	// meta data API
+	void SetMetaData(const std::string& name, const char* data);
+	void SetMetaData(const std::string& name, uint32_t data);
+	bool HasMetaData(const std::string& name);
+	const char * GetMetaDataS(const std::string& name);
+	uint32_t GetMetaDataI(const std::string& name);
+
 };
 
 typedef std::shared_ptr<Shot>	ShotRef;

--- a/src/bzfs/ShotManager.h
+++ b/src/bzfs/ShotManager.h
@@ -73,7 +73,8 @@ public:
 	double		LastUpdateTime;
 	double		StartTime;
 
-	std::map<std::string,uint32_t> MetaData;
+	std::map<std::string, std::string> stringMetaData;
+	std::map<std::string, uint32_t> intMetaData;
 
 	FiringInfo	Info;
 

--- a/src/bzfs/WorldWeapons.cxx
+++ b/src/bzfs/WorldWeapons.cxx
@@ -31,7 +31,7 @@
 
 static uint32_t fireWorldWepReal(FlagType* type, float lifetime, PlayerId player,
 			    TeamColor teamColor, float *pos, float tilt, float dir, float shotSpeed,
-			    int shotID, float dt, PlayerId targetPlayerID = -1)
+			    int shotID, float delayTime, PlayerId targetPlayerID = -1)
 {
   if (!BZDB.isTrue(StateDatabase::BZDB_WEAPONS)) {
     return INVALID_SHOT_GUID;
@@ -54,7 +54,7 @@ static uint32_t fireWorldWepReal(FlagType* type, float lifetime, PlayerId player
   firingInfo.shot.vel[1] = shotSpeed * tiltFactor * sinf(dir);
   firingInfo.shot.vel[2] = shotSpeed * sinf(tilt);
   firingInfo.shot.id = shotID;
-  firingInfo.shot.dt = dt;
+  firingInfo.shot.dt = delayTime;
 
   firingInfo.shot.team = teamColor;
 
@@ -303,19 +303,19 @@ void WorldWeaponGlobalEventHandler::process (bz_EventData *eventData)
 // for bzfsAPI: it needs to be global
 uint32_t fireWorldWep(FlagType* type, float lifetime, PlayerId player,
 			float *pos, float tilt, float direction, float speed,
-			int shotID, float dt, TeamColor shotTeam, PlayerId targetPlayerId)
+			int shotID, float delayTime, TeamColor shotTeam, PlayerId targetPlayerId)
 {
   return fireWorldWepReal(type, lifetime, player, shotTeam,
-			  pos, tilt, direction, speed, shotID, dt, targetPlayerId);
+			  pos, tilt, direction, speed, shotID, delayTime, targetPlayerId);
 }
 
 
 // DEPRECATED
 uint32_t fireWorldGM(FlagType* type, PlayerId targetPlayerID, float lifetime,
 		PlayerId player, float *pos, float tilt, float direction,
-		int shotID, float dt, TeamColor shotTeam)
+		int shotID, float delayTime, TeamColor shotTeam)
 {
-  return fireWorldWepReal(type, lifetime, player, shotTeam, pos, tilt, direction, -1, shotID, dt, targetPlayerID);
+  return fireWorldWepReal(type, lifetime, player, shotTeam, pos, tilt, direction, -1, shotID, delayTime, targetPlayerID);
 }
 
 // Local Variables: ***

--- a/src/bzfs/WorldWeapons.cxx
+++ b/src/bzfs/WorldWeapons.cxx
@@ -56,9 +56,14 @@ uint32_t WorldWeapons::fireShot(FlagType* type, float lifetime, float *pos, floa
 
   if (shotID != NULL && shotID == 0) {
     *shotID = getNewWorldShotID();
+    firingInfo.shot.id = *shotID;
   }
-
-  firingInfo.shot.id = *shotID;
+  else if (shotID == NULL) {
+    firingInfo.shot.id = getNewWorldShotID();
+  }
+  else {
+    firingInfo.shot.id = *shotID;
+  }
 
   buf = firingInfo.pack(bufStart);
 

--- a/src/bzfs/WorldWeapons.cxx
+++ b/src/bzfs/WorldWeapons.cxx
@@ -76,7 +76,20 @@ static uint32_t fireWorldWepReal(FlagType* type, float lifetime, PlayerId player
     broadcastMessage(MsgGMUpdate, sizeof(packet), packet);
   }
 
+  bz_ServerShotFiredEventData_V1 event;
+  event.guid = shotGUID;
+  event.flagType = type->flagAbbv;
+  event.lifetime = lifetime;
+  event.pos[0] = pos[0];
+  event.pos[1] = pos[1];
+  event.pos[2] = pos[2];
+  event.lookAt[0] = cosf(dir);
+  event.lookAt[1] = sinf(dir);
+  event.lookAt[2] = sinf(tilt);
+  event.team = convertTeam(teamColor);
 
+  WorldEventManager worldEventManager;
+  worldEventManager.callEvents(bz_eServerShotFiredEvent, &event);
 
   return shotGUID;
 }

--- a/src/bzfs/WorldWeapons.h
+++ b/src/bzfs/WorldWeapons.h
@@ -46,7 +46,7 @@ public:
   int packSize() const;
   void *pack(void *buf) const;
 
-  uint32_t fireShot(FlagType* type, float lifetime, float *pos, float tilt, float direction, float shotSpeed, int *shotID, float delayTime, TeamColor teamColor = RogueTeam, PlayerId targetPlayerID = -1);
+  uint32_t fireShot(FlagType* type, float lifetime, const float origin[3], const float vector[3], float shotSpeed, int *shotID, float delayTime, TeamColor teamColor = RogueTeam, PlayerId targetPlayerID = -1);
 
 private:
   struct Weapon

--- a/src/bzfs/WorldWeapons.h
+++ b/src/bzfs/WorldWeapons.h
@@ -86,8 +86,8 @@ protected:
 	bz_eTeamType	team;
 };
 
-uint32_t fireWorldWep(FlagType* type, float lifetime, PlayerId player, float *pos, float tilt, float direction, float speed, int shotID, float dt, TeamColor shotTeam = RogueTeam, PlayerId targetPlayerID = -1);
-uint32_t fireWorldGM(FlagType* type, PlayerId targetPlayerID, float lifetime, PlayerId player, float *pos, float tilt, float direction, int shotID, float dt, TeamColor shotTeam = RogueTeam);
+uint32_t fireWorldWep(FlagType* type, float lifetime, PlayerId player, float *pos, float tilt, float direction, float speed, int shotID, float delayTime, TeamColor shotTeam = RogueTeam, PlayerId targetPlayerID = -1);
+uint32_t fireWorldGM(FlagType* type, PlayerId targetPlayerID, float lifetime, PlayerId player, float *pos, float tilt, float direction, int shotID, float delayTime, TeamColor shotTeam = RogueTeam);
 
 #endif
 

--- a/src/bzfs/WorldWeapons.h
+++ b/src/bzfs/WorldWeapons.h
@@ -86,9 +86,9 @@ protected:
 	bz_eTeamType	team;
 };
 
-int fireWorldWep ( FlagType* type, float lifetime, PlayerId player, float *pos, float tilt, float direction, float speed, int shotID, float dt, TeamColor shotTeam = RogueTeam );
+uint32_t fireWorldWep(FlagType* type, float lifetime, PlayerId player, float *pos, float tilt, float direction, float speed, int shotID, float dt, TeamColor shotTeam = RogueTeam, PlayerId targetPlayerID = -1);
+uint32_t fireWorldGM(FlagType* type, PlayerId targetPlayerID, float lifetime, PlayerId player, float *pos, float tilt, float direction, int shotID, float dt, TeamColor shotTeam = RogueTeam);
 
-int fireWorldGM(FlagType* type, PlayerId targetPlayerID, float lifetime, PlayerId player, float *pos, float tilt, float direction, int shotID, float dt, TeamColor shotTeam = RogueTeam);
 #endif
 
 // Local Variables: ***

--- a/src/bzfs/WorldWeapons.h
+++ b/src/bzfs/WorldWeapons.h
@@ -46,7 +46,7 @@ public:
   int packSize() const;
   void *pack(void *buf) const;
 
-  uint32_t fireShot(FlagType* type, float lifetime, PlayerId player, float *pos, float tilt, float direction, float shotSpeed, int *shotID, float delayTime, TeamColor teamColor = RogueTeam, PlayerId targetPlayerID = -1);
+  uint32_t fireShot(FlagType* type, float lifetime, float *pos, float tilt, float direction, float shotSpeed, int *shotID, float delayTime, TeamColor teamColor = RogueTeam, PlayerId targetPlayerID = -1);
 
 private:
   struct Weapon

--- a/src/bzfs/WorldWeapons.h
+++ b/src/bzfs/WorldWeapons.h
@@ -46,8 +46,7 @@ public:
   int packSize() const;
   void *pack(void *buf) const;
 
-  int getNewWorldShotID ( void );
-  int getNewWorldShotID(PlayerId player);
+  uint32_t fireShot(FlagType* type, float lifetime, PlayerId player, float *pos, float tilt, float direction, float shotSpeed, int *shotID, float delayTime, TeamColor teamColor = RogueTeam, PlayerId targetPlayerID = -1);
 
 private:
   struct Weapon
@@ -65,6 +64,8 @@ private:
 
   std::vector<Weapon*> weapons;
   int worldShotId;
+
+  int getNewWorldShotID(void);
 
   WorldWeapons( const WorldWeapons &w);
   WorldWeapons& operator=(const WorldWeapons &w) const;
@@ -85,9 +86,6 @@ protected:
 	float		tilt;
 	bz_eTeamType	team;
 };
-
-uint32_t fireWorldWep(FlagType* type, float lifetime, PlayerId player, float *pos, float tilt, float direction, float speed, int shotID, float delayTime, TeamColor shotTeam = RogueTeam, PlayerId targetPlayerID = -1);
-uint32_t fireWorldGM(FlagType* type, PlayerId targetPlayerID, float lifetime, PlayerId player, float *pos, float tilt, float direction, int shotID, float delayTime, TeamColor shotTeam = RogueTeam);
 
 #endif
 

--- a/src/bzfs/bzfs.cxx
+++ b/src/bzfs/bzfs.cxx
@@ -4004,12 +4004,13 @@ static void shotFired(int playerIndex, void *buf, int len)
 
 static void shotEnded(const PlayerId& id, int16_t shotIndex, uint16_t reason)
 {
-  GameKeeper::Player *playerData
-    = GameKeeper::Player::getPlayerByIndex(id);
-  if (!playerData)
+  GameKeeper::Player *playerData = GameKeeper::Player::getPlayerByIndex(id);
+
+  if (!playerData && id != ServerPlayer)
     return;
 
-  playerData->removeShot(shotIndex & 0xff, shotIndex >> 8);
+  if (id != ServerPlayer)
+    playerData->removeShot(shotIndex & 0xff, shotIndex >> 8);
 
   ShotManager.RemoveShot(ShotManager.FindShotGUID(id,shotIndex & 0xff));
 

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1721,7 +1721,7 @@ BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL )
   return true;
 }
 
-BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam )
+DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, int UNUSED(fromPlayer), float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam)
 {
   if (!pos || !flagType)
     return false;
@@ -1731,21 +1731,15 @@ BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPla
     return false;
 
   FlagType *flag = flagMap.find(std::string(flagType))->second;
-
-  PlayerId player;
-  if ( fromPlayer == BZ_SERVER )
-    player = ServerPlayer;
-  else
-    player = fromPlayer;
 
   int realShotID = shotID;
-  if ( realShotID == 0)
-    realShotID = world->getWorldWeapons().getNewWorldShotID();
+  if (realShotID == 0)
+    realShotID = NULL;
 
-  return fireWorldWep(flag,lifetime,player,pos,tilt,direction,-1,realShotID,dt,(TeamColor)convertTeam(shotTeam)) == realShotID;
+  return fireWorldWep(flag, lifetime, ServerPlayer, pos, tilt, direction, -1, realShotID, dt, (TeamColor)convertTeam(shotTeam));
 }
 
-BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam )
+DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, int UNUSED(fromPlayer), float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam)
 {
   if (!pos || !flagType)
     return false;
@@ -1756,46 +1750,27 @@ BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPla
 
   FlagType *flag = flagMap.find(std::string(flagType))->second;
 
-  PlayerId player;
-  if ( fromPlayer == BZ_SERVER )
-    player = ServerPlayer;
-  else
-    player = fromPlayer;
-
-  int realShotID = world->getWorldWeapons().getNewWorldShotID(player);
+  int realShotID = world->getWorldWeapons().getNewWorldShotID(ServerPlayer);
 
   if (shotID != NULL)
     *shotID = realShotID;
 
-  return fireWorldWep(flag,lifetime,player,pos,tilt,direction, speed,realShotID,dt,(TeamColor)convertTeam(shotTeam)) == realShotID;
+  return fireWorldWep(flag, lifetime, ServerPlayer, pos, tilt, direction, speed, realShotID, dt, (TeamColor)convertTeam(shotTeam));
 }
 
-BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam )
+DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam)
 {
-  return bz_fireWorldWep(flagType, lifetime, fromPlayer, pos, tilt, direction, -1, shotID, dt, shotTeam );
+  return bz_fireWorldWep(flagType, lifetime, fromPlayer, pos, tilt, direction, -1, shotID, dt, shotTeam);
 }
 
-BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam)
+DEPRECATED BZF_API int bz_fireWorldGM(int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam)
 {
-  const char* flagType = "GM";
-
-  if (!pos || !flagType)
+  if (!pos)
     return false;
 
-  FlagTypeMap &flagMap = FlagType::getFlagMap();
-  if (flagMap.find(std::string(flagType)) == flagMap.end())
-    return false;
+  bz_fireServerShot("GM", lifetime, pos, tilt, direction, shotTeam, targetPlayerID);
 
-  FlagType *flag = flagMap.find(std::string(flagType))->second;
-
-  PlayerId player = ServerPlayer;
-
-  int shotID =  world->getWorldWeapons().getNewWorldShotID();
-
-  fireWorldGM(flag,targetPlayerID, lifetime,player,pos,tilt,direction,
-    shotID, dt, (TeamColor)convertTeam(shotTeam));
-
-  return shotID;
+  return world->getWorldWeapons().getNewWorldShotID();
 }
 
 BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float lookAtVector[3], bz_eTeamType color, int targetPlayerId)

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1722,7 +1722,7 @@ BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL )
 }
 
 // old API, many arguments get ingored.
-/*DEPRECATED*/ BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, int UNUSED(shotID), float UNUSED(dt), bz_eTeamType shotTeam)
+BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, int UNUSED(shotID), float UNUSED(dt), bz_eTeamType shotTeam)
 {
   float v[3] = { 0,0,0 };
   if (flagType == nullptr || !pos || !bz_vectorFromRotations(tilt, direction, v))
@@ -1732,7 +1732,7 @@ BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL )
   return true;
 }
 
-/*DEPRECATED*/ BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, float UNUSED(speed), int* shotID, float UNUSED(dt), bz_eTeamType shotTeam)
+BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, float UNUSED(speed), int* shotID, float UNUSED(dt), bz_eTeamType shotTeam)
 {
   float v[3] = { 0,0,0 };
   if (flagType == nullptr || !pos || !bz_vectorFromRotations(tilt, direction, v))
@@ -1742,7 +1742,7 @@ BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL )
   return true;
 }
 
-/*DEPRECATED*/ BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, int* shotID, float UNUSED(dt), bz_eTeamType shotTeam)
+BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, int* shotID, float UNUSED(dt), bz_eTeamType shotTeam)
 {
   float v[3] = { 0,0,0 };
   if (flagType == nullptr || !pos || !bz_vectorFromRotations(tilt, direction, v))
@@ -1752,7 +1752,7 @@ BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL )
   return true;
 }
 
-/*DEPRECATED*/ BZF_API int bz_fireWorldGM(int targetPlayerID, float UNUSED(lifetime), float *pos, float tilt, float direction, float UNUSED(dt), bz_eTeamType shotTeam)
+BZF_API int bz_fireWorldGM(int targetPlayerID, float UNUSED(lifetime), float *pos, float tilt, float direction, float UNUSED(dt), bz_eTeamType shotTeam)
 {
   float v[3] = { 0,0,0 };
   if (!pos || !bz_vectorFromRotations(tilt, direction, v))

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1793,17 +1793,6 @@ BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float o
   return world->getWorldWeapons().fireShot(flag, lifetime, origin, tilt, direction, -1, NULL, 0, (TeamColor)convertTeam(color), targetPlayerId);
 }
 
-BZF_API bool bz_endServerShot(uint32_t shotGUID)
-{
-  if (shotGUID == 0 || shotGUID == NULL)
-    return false;
-
-  Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
-  shot->End();
-
-  return true;
-}
-
 BZF_API const bz_ApiString bz_getShotMetaData(const uint32_t shotGUID, const char* name)
 {
   if (shotGUID == 0 || shotGUID == NULL || name == NULL)

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1804,7 +1804,7 @@ BZF_API bool bz_endServerShot(uint32_t shotGUID)
   return true;
 }
 
-BZF_API bz_ApiString bz_getShotMetaData(const uint32_t shotGUID, const char* name)
+BZF_API const bz_ApiString bz_getShotMetaData(const uint32_t shotGUID, const char* name)
 {
   if (shotGUID == 0 || shotGUID == NULL || name == NULL)
     return NULL;
@@ -1812,14 +1812,33 @@ BZF_API bz_ApiString bz_getShotMetaData(const uint32_t shotGUID, const char* nam
   Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
   std::string key = name;
 
-  if (shot->shotMetaData.find(key) == shot->shotMetaData.end())
+  if (shot->stringMetaData.find(key) == shot->stringMetaData.end())
     return NULL;
 
-  return shot->shotMetaData[key];
+  return bz_ApiString(shot->stringMetaData[key]);
 }
 
-//BZF_API bool bz_hasShotMetaData(const uint32_t shotGUID, const char* name);
-//BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, const bz_ApiString value);
+BZF_API bool bz_hasShotMetaData(const uint32_t shotGUID, const char* name)
+{
+  if (shotGUID == 0 || shotGUID == NULL || name == NULL)
+    return NULL;
+
+  Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
+  std::string key = name;
+
+  return (shot->stringMetaData.find(key) == shot->stringMetaData.end());
+}
+
+BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, const char* value)
+{
+  if (shotGUID == 0 || shotGUID == NULL || name == NULL)
+    return;
+
+  Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
+  std::string key = name;
+
+  shot->stringMetaData[key] = std::string(value);
+}
 
 BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name)
 {
@@ -1831,10 +1850,10 @@ BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* nam
   Shots::ShotRef shot = ShotManager.FindShot(shotGUId);
 
   std::string n = name;
-  if (shot->MetaData.find(n) == shot->MetaData.end())
+  if (shot->intMetaData.find(n) == shot->intMetaData.end())
     return 0;
 
-  return shot->MetaData[n];
+  return shot->intMetaData[n];
 }
 
 BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value)
@@ -1847,7 +1866,7 @@ BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, u
   Shots::ShotRef shot = ShotManager.FindShot(shotGUId);
 
   std::string n = name;
-  shot->MetaData[n] = value;
+  shot->intMetaData[n] = value;
 }
 
 BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name)
@@ -1860,7 +1879,7 @@ BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name)
   Shots::ShotRef shot = ShotManager.FindShot(shotGUId);
 
   std::string n = name;
-  if (shot->MetaData.find(n) == shot->MetaData.end())
+  if (shot->intMetaData.find(n) == shot->intMetaData.end())
     return false;
 
   return true;

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1736,7 +1736,7 @@ DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, in
   if (shotID == 0)
     realShotID = NULL;
 
-  return world->getWorldWeapons().fireShot(flag, lifetime, ServerPlayer, pos, tilt, direction, -1, realShotID, dt, (TeamColor)convertTeam(shotTeam));
+  return world->getWorldWeapons().fireShot(flag, lifetime, pos, tilt, direction, -1, realShotID, dt, (TeamColor)convertTeam(shotTeam));
 }
 
 DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, int UNUSED(fromPlayer), float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam)
@@ -1750,12 +1750,12 @@ DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, in
 
   FlagType *flag = flagMap.find(std::string(flagType))->second;
 
-  return world->getWorldWeapons().fireShot(flag, lifetime, ServerPlayer, pos, tilt, direction, speed, shotID, dt, (TeamColor)convertTeam(shotTeam));
+  return world->getWorldWeapons().fireShot(flag, lifetime, pos, tilt, direction, speed, shotID, dt, (TeamColor)convertTeam(shotTeam));
 }
 
-DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam)
+DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, int UNUSED(fromPlayer), float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam)
 {
-  return bz_fireWorldWep(flagType, lifetime, fromPlayer, pos, tilt, direction, -1, shotID, dt, shotTeam);
+  return bz_fireWorldWep(flagType, lifetime, ServerPlayer, pos, tilt, direction, -1, shotID, dt, shotTeam);
 }
 
 DEPRECATED BZF_API int bz_fireWorldGM(int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam)
@@ -1790,7 +1790,7 @@ BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float o
 
   FlagType *flag = flagMap.find(flagType)->second;
 
-  return world->getWorldWeapons().fireShot(flag, lifetime, ServerPlayer, origin, tilt, direction, -1, NULL, 0, (TeamColor)convertTeam(color), targetPlayerId);
+  return world->getWorldWeapons().fireShot(flag, lifetime, origin, tilt, direction, -1, NULL, 0, (TeamColor)convertTeam(color), targetPlayerId);
 }
 
 BZF_API bool bz_endServerShot(uint32_t shotGUID)

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1798,6 +1798,30 @@ BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, flo
   return shotID;
 }
 
+BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float lookAtVector[3], bz_eTeamType color, int targetPlayerId)
+{
+  float tilt = asinf(lookAtVector[3]);
+  float direction = atan2f(lookAtVector[0], lookAtVector[1]);
+
+  return bz_fireServerShot(shotType, lifetime, origin, tilt, direction, color, targetPlayerId);
+}
+
+BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float tilt, float direction, bz_eTeamType color, int targetPlayerId)
+{
+  if (!shotType || !origin)
+    return false;
+
+  std::string flagType = shotType;
+  FlagTypeMap &flagMap = FlagType::getFlagMap();
+
+  if (flagMap.find(flagType) == flagMap.end())
+    return false;
+
+  FlagType *flag = flagMap.find(flagType)->second;
+
+  return fireWorldWep(flag, lifetime, ServerPlayer, origin, tilt, direction, -1, NULL, 0, (TeamColor)convertTeam(color), targetPlayerId);
+}
+
 BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name)
 {
   uint32_t shotGUId = ShotManager.FindShotGUID(fromPlayer,shotID);

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1782,6 +1782,27 @@ BZF_API uint32_t bz_fireServerShot(const char* shotType, float origin[3], float 
   return world->getWorldWeapons().fireShot(flag, lifetime, origin, vector, -1, nullptr, 0, (TeamColor)convertTeam(color), targetPlayerId);
 }
 
+BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name)
+{
+  uint32_t guid = bz_getShotGUID(fromPlayer, shotID);
+
+  return bz_getShotMetaDataI(guid, name);
+}
+
+BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value)
+{
+  uint32_t guid = bz_getShotGUID(fromPlayer, shotID);
+
+  bz_setShotMetaData(guid, name, value);
+}
+
+BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name)
+{
+  uint32_t guid = bz_getShotGUID(fromPlayer, shotID);
+
+  return bz_shotHasMetaData(guid, name);
+}
+
 // math helpers
 BZF_API bool bz_vectorFromPoints(const float p1[3], const float p2[3], float outVec[3])
 {

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1728,8 +1728,7 @@ BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int U
   if (flagType == nullptr || !pos || !bz_vectorFromRotations(tilt, direction, v))
     return false;
 
-  (int)bz_fireServerShot(flagType, pos, v, shotTeam, -1);
-  return true;
+  return (int)bz_fireServerShot(flagType, pos, v, shotTeam, -1);
 }
 
 BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, float UNUSED(speed), int* shotID, float UNUSED(dt), bz_eTeamType shotTeam)

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1822,6 +1822,17 @@ BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float o
   return fireWorldWep(flag, lifetime, ServerPlayer, origin, tilt, direction, -1, NULL, 0, (TeamColor)convertTeam(color), targetPlayerId);
 }
 
+BZF_API bool bz_endServerShot(uint32_t shotGUID)
+{
+  if (shotGUID == 0 || shotGUID == NULL)
+    return false;
+
+  Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
+  shot->End();
+
+  return true;
+}
+
 BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name)
 {
   uint32_t shotGUId = ShotManager.FindShotGUID(fromPlayer,shotID);

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1887,7 +1887,12 @@ BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name)
 
 BZF_API uint32_t bz_getShotGUID (int fromPlayer, int shotID)
 {
-  return ShotManager.FindShotGUID(fromPlayer,shotID);
+  int shotOwnerID = fromPlayer;
+
+  if (shotOwnerID == BZ_SERVER)
+    shotOwnerID = ServerPlayer;
+
+  return ShotManager.FindShotGUID(shotOwnerID, shotID);
 }
 
 // time API


### PR DESCRIPTION
- A lot of refactoring for World Weapon functionality
- Add new `bz_eServerShotFiredEvent`
- Introduce `bz_fireServerShot()` API function
- Remove World Weapon shots from all tanks when they've been ended
- Use a GUID for each World Weapon shot by the API

I'd really appreciate help testing and feedback.

Stuff left to do:

- [x] test world weapon GMs shot by the API
- [x] test `oncap` world weapons
- [x] Port rabidRabbit, shockwavedeath, wwzones plugins to use new API function