### PR TITLE
Fix number pad key mapping

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 BZFlag 2.4.13
 -------------
 
+* Treat the number pad keys uniquely for key mapping - Scott Wichser
 * Better cpu selection for x86_64 - Alfredo Tupone
 * Fix build with enable-profile - Alfredo Tupone
 * Add safety check when getting flags (bzfs) - Alfredo Tupone

--- a/src/common/KeyManager.cxx
+++ b/src/common/KeyManager.cxx
@@ -250,11 +250,21 @@ std::string		KeyManager::get(const BzfKeyEvent& key,
 {
   const EventToCommandMap* map = press ? &pressEventToCommand :
     &releaseEventToCommand;
-  EventToCommandMap::const_iterator index = map->find(key);
-  if (index == map->end())
-    return "";
-  else
-    return index->second;
+  // If this key has both a button and an ascii value, search the hard way
+  if (key.ascii != '\0' && key.button != BzfKeyEvent::NoButton) {
+    for (EventToCommandMap::const_iterator index = map->begin(); index != map->end(); ++index) {
+      // If either the ascii or button match, return it
+      if ((index->first.ascii == key.ascii || index->first.button == key.button) && index->first.shift == key.shift)
+        return index->second;
+    }
+  } else {
+    // Otherwise just look for an exact match
+    EventToCommandMap::const_iterator index = map->find(key);
+    if (index != map->end())
+      return index->second;
+  }
+
+  return "";
 }
 
 

--- a/src/common/KeyManager.cxx
+++ b/src/common/KeyManager.cxx
@@ -299,9 +299,9 @@ std::string		KeyManager::keyEventToString(
     name += "Ctrl+";
   if (key.shift & BzfKeyEvent::AltKey)
     name += "Alt+";
+  if (key.button != BzfKeyEvent::NoButton)
+    return name + buttonNames[key.button];
   switch (key.ascii) {
-    case 0:
-      return name + buttonNames[key.button];
     case '\b':
       return name + "Backspace";
     case '\t':

--- a/src/platform/SDL2Display.cxx
+++ b/src/platform/SDL2Display.cxx
@@ -193,7 +193,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_0:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp0;
       key.ascii = '0';
     } else {
       key.button = BzfKeyEvent::Insert;
@@ -201,7 +201,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_1:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp1;
       key.ascii = '1';
     } else {
       key.button = BzfKeyEvent::End;
@@ -209,7 +209,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_2:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp2;
       key.ascii = '2';
     } else {
       key.button = BzfKeyEvent::Down;
@@ -217,7 +217,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_3:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp3;
       key.ascii = '3';
     } else {
       key.button = BzfKeyEvent::PageDown;
@@ -225,7 +225,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_4:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp4;
       key.ascii = '4';
     } else {
       key.button = BzfKeyEvent::Left;
@@ -233,7 +233,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_5:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp5;
       key.ascii = '5';
     } else {
       // When numlock is turned off, the keypad 5 key should do nothing
@@ -242,7 +242,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_6:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp6;
       key.ascii = '6';
     } else {
       key.button = BzfKeyEvent::Right;
@@ -250,7 +250,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_7:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp7;
       key.ascii = '7';
     } else {
       key.button = BzfKeyEvent::Home;
@@ -258,7 +258,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_8:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp8;
       key.ascii = '8';
     } else {
       key.button = BzfKeyEvent::Up;
@@ -266,7 +266,7 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_9:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp9;
       key.ascii = '9';
     } else {
       key.button = BzfKeyEvent::PageUp;
@@ -274,34 +274,34 @@ bool SDLDisplay::getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char 
     break;
   case SDLK_KP_PERIOD:
     if (mod & KMOD_NUM) {
-      key.button = BzfKeyEvent::NoButton;
+      key.button = BzfKeyEvent::Kp_Period;
       key.ascii = '.';
     } else {
       key.button = BzfKeyEvent::Delete;
     }
     break;
   case SDLK_KP_DIVIDE:
-    key.button = BzfKeyEvent::NoButton;
+    key.button = BzfKeyEvent::Kp_Divide;
     key.ascii = '/';
     break;
   case SDLK_KP_MULTIPLY:
-    key.button = BzfKeyEvent::NoButton;
+    key.button = BzfKeyEvent::Kp_Multiply;
     key.ascii = '*';
     break;
   case SDLK_KP_MINUS:
-    key.button = BzfKeyEvent::NoButton;
+    key.button = BzfKeyEvent::Kp_Minus;
     key.ascii = '-';
     break;
   case SDLK_KP_PLUS:
-    key.button = BzfKeyEvent::NoButton;
+    key.button = BzfKeyEvent::Kp_Plus;
     key.ascii = '+';
     break;
   case SDLK_KP_ENTER:
-    key.button = BzfKeyEvent::NoButton;
+    key.button = BzfKeyEvent::Kp_Enter;
     key.ascii = 13;
     break;
   case SDLK_KP_EQUALS:
-    key.button = BzfKeyEvent::NoButton;
+    key.button = BzfKeyEvent::Kp_Equals;
     key.ascii = '=';
     break;
   case SDLK_HELP:


### PR DESCRIPTION
This should fix #104.  Tested it on Windows and Linux with SDL2, but could still use a test on macOS.