### PR TITLE
Fix for octree crash after allman formatting changes

### DIFF
--- a/src/scene/Octree.cxx
+++ b/src/scene/Octree.cxx
@@ -1,14 +1,14 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
- *
- * This package is free software;  you can redistribute it and/or
- * modify it under the terms of the license found in the file
- * named COPYING that should have accompanied this file.
- *
- * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
- */
+* Copyright (c) 1993-2018 Tim Riker
+*
+* This package is free software;  you can redistribute it and/or
+* modify it under the terms of the license found in the file
+* named COPYING that should have accompanied this file.
+*
+* THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+*/
 
 #include "common.h"
 
@@ -29,7 +29,7 @@
 static bool F2BSORT = true;//FIXME
 
 
-// FIXME - do something about occluders vs. gridding
+                           // FIXME - do something about occluders vs. gridding
 
 
 static const int fullListBreak = 3; // FIXME
@@ -48,27 +48,21 @@ static int CullListCount = 0;
 static SceneNode** CullList = NULL;
 static const Frustum* CullFrustum = NULL;
 static int ShadowCount = 0;
-static const float (*ShadowPlanes)[4];
+static const float(*ShadowPlanes)[4];
 
 static OccluderManager OcclMgrs[2];
 static OccluderManager* OcclMgr = &OcclMgrs[0];
 
 
-#ifdef USE_REAL_INLINE
-inline static void addCullListNode (SceneNode* node)
+inline static void addCullListNode(SceneNode* node)
 {
     CullList[CullListCount] = node;
     CullListCount++;
     return;
 }
-#else
-#define addCullListNode(node)       \
-  CullList[CullListCount] = node;   \
-  CullListCount++;
-#endif
 
 
-inline static void squeezeChildren (OctreeNode** children)
+inline static void squeezeChildren(OctreeNode** children)
 {
     for (int dst = 0; dst < 8; dst++)
     {
@@ -117,18 +111,14 @@ Octree::~Octree()
 void Octree::setOccluderManager(int occlmgr)
 {
     if (occlmgr == 1)
-    {
         OcclMgr = &OcclMgrs[1]; // mirror
-    }
     else
-    {
         OcclMgr = &OcclMgrs[0]; // normal
-    }
     return;
 }
 
 
-void Octree::clear ()
+void Octree::clear()
 {
     delete root;
     root = NULL;
@@ -142,7 +132,7 @@ void Octree::clear ()
 }
 
 
-void Octree::addNodes (SceneNode** list, int listSize, int depth, int elements)
+void Octree::addNodes(SceneNode** list, int listSize, int depth, int elements)
 {
     int i;
 
@@ -159,7 +149,7 @@ void Octree::addNodes (SceneNode** list, int listSize, int depth, int elements)
     CullList = list;
     CullListSize = listSize;
 
-    getExtents (list, listSize);
+    getExtents(list, listSize);
 
     // making babies
     root = new OctreeNode(0, extents, list, listSize);
@@ -169,36 +159,33 @@ void Octree::addNodes (SceneNode** list, int listSize, int depth, int elements)
     totalElements = 0;
     root->tallyStats();
 
-    logDebugMessage(2,"Octree scene nodes = %i\n", listSize);
+    logDebugMessage(2, "Octree scene nodes = %i\n", listSize);
     for (i = 0; i < 3; i++)
-    {
-        logDebugMessage(2,"  grid extent[%i] = %f, %f\n", i, extents.mins[i],
-                        extents.maxs[i]);
-    }
+        logDebugMessage(2, "  grid extent[%i] = %f, %f\n", i, extents.mins[i], extents.maxs[i]);
+
     for (i = 0; i < 3; i++)
-    {
-        logDebugMessage(2,"  visual extent[%i] = %f, %f\n", i, visualExtents.mins[i],
-                        visualExtents.maxs[i]);
-    }
-    logDebugMessage(2,"Octree leaf nodes  = %i\n", leafNodes);
-    logDebugMessage(2,"Octree total nodes = %i\n", totalNodes);
-    logDebugMessage(2,"Octree total elements = %i\n", totalElements);
+        logDebugMessage(2, "  visual extent[%i] = %f, %f\n", i, visualExtents.mins[i], visualExtents.maxs[i]);
+
+    logDebugMessage(2, "Octree leaf nodes  = %i\n", leafNodes);
+    logDebugMessage(2, "Octree total nodes = %i\n", totalNodes);
+    logDebugMessage(2, "Octree total elements = %i\n", totalElements);
 
     return;
 }
 
 
-int Octree::getFrustumList (SceneNode** list, int listSize,
-                            const Frustum* frustum) const
+int Octree::getFrustumList(SceneNode** list, int listSize,
+    const Frustum* frustum) const
 {
     if (!root)
         return 0;
+
     F2BSORT = BZDB.isTrue("f2bsort");
 
     if (listSize > CullListSize)
     {
-        printf ("Octree::getFrustumList() internal error!\n");
-        exit (1);
+        printf("Octree::getFrustumList() internal error!\n");
+        exit(1);
     }
 
     CullFrustum = frustum;
@@ -218,8 +205,8 @@ int Octree::getFrustumList (SceneNode** list, int listSize,
 }
 
 
-int Octree::getRadarList (SceneNode** list, int listSize,
-                          const Frustum* frustum) const
+int Octree::getRadarList(SceneNode** list, int listSize,
+    const Frustum* frustum) const
 {
     // This is basically the same as Octree::getFrustumList(),
     // except that it doesn't use the occluders. This duplication
@@ -230,8 +217,8 @@ int Octree::getRadarList (SceneNode** list, int listSize,
 
     if (listSize > CullListSize)
     {
-        printf ("Octree::getRadarList() internal error!\n");
-        exit (1);
+        printf("Octree::getRadarList() internal error!\n");
+        exit(1);
     }
 
     CullFrustum = frustum;
@@ -245,16 +232,16 @@ int Octree::getRadarList (SceneNode** list, int listSize,
 }
 
 
-int Octree::getShadowList (SceneNode** list, int listSize,
-                           int planeCount, const float (*planes)[4]) const
+int Octree::getShadowList(SceneNode** list, int listSize,
+    int planeCount, const float(*planes)[4]) const
 {
     if (!root)
         return 0;
 
     if (listSize > CullListSize)
     {
-        printf ("Octree::getShadowList() internal error!\n");
-        exit (1);
+        printf("Octree::getShadowList() internal error!\n");
+        exit(1);
     }
 
     ShadowCount = planeCount;
@@ -273,7 +260,7 @@ int Octree::getShadowList (SceneNode** list, int listSize,
 }
 
 
-void Octree::getExtents (SceneNode** list, int listSize)
+void Octree::getExtents(SceneNode** list, int listSize)
 {
     int i;
 
@@ -294,7 +281,9 @@ void Octree::getExtents (SceneNode** list, int listSize)
     {
         float axisWidth = tmpExts.getWidth(i);
         if (axisWidth > width)
+        {
             width = axisWidth;
+        }
     }
 
     extents = tmpExts;
@@ -316,24 +305,24 @@ void Octree::getExtents (SceneNode** list, int listSize)
 }
 
 
-void Octree::draw () const
+void Octree::draw() const
 {
     if (!root)
         return;
 
     GLboolean usingTextures;
     glGetBooleanv(GL_TEXTURE_2D, &usingTextures);
-    glDisable (GL_TEXTURE_2D);
+    glDisable(GL_TEXTURE_2D);
 
     // CullFrustum needs to still be valid here
     // It should still exist in SceneRender.cxx
     // when this function is called.
-    root->draw ();
+    root->draw();
     OcclMgr->update(CullFrustum);
     OcclMgr->draw();
 
     if (usingTextures)
-        glEnable (GL_TEXTURE_2D);
+        glEnable(GL_TEXTURE_2D);
 
     return;
 }
@@ -346,7 +335,7 @@ void Octree::draw () const
 
 
 OctreeNode::OctreeNode(unsigned char _depth, const Extents& exts,
-                       SceneNode** _list, int _listSize)
+    SceneNode** _list, int _listSize)
 {
     int i;
 
@@ -360,9 +349,9 @@ OctreeNode::OctreeNode(unsigned char _depth, const Extents& exts,
     childCount = 0;
 
     // copy the incoming list
-    const int listBytes = _listSize * sizeof (SceneNode*);
-    list = (SceneNode**) malloc (listBytes);
-    memcpy (list, _list, listBytes);
+    const int listBytes = _listSize * sizeof(SceneNode*);
+    list = (SceneNode**)malloc(listBytes);
+    memcpy(list, _list, listBytes);
 
     // copy the extents, and make a slighty puffed up version
     extents = exts;
@@ -375,7 +364,7 @@ OctreeNode::OctreeNode(unsigned char _depth, const Extents& exts,
     for (i = 0; i < _listSize; i++)
     {
         SceneNode* node = _list[i];
-        if (node->inAxisBox (testExts))
+        if (node->inAxisBox(testExts))
         {
             list[listSize] = node;
             listSize++;
@@ -388,7 +377,7 @@ OctreeNode::OctreeNode(unsigned char _depth, const Extents& exts,
 
     // resize the list to save space
     // FIXME: Correctly handle the situation of the realloc failing (which would return a NULL pointer)
-    list = (SceneNode**) realloc (list, count * sizeof (SceneNode*));
+    list = (SceneNode**)realloc(list, count * sizeof(SceneNode*));
 
     // return if this is a leaf node
     if (((int)depth >= maxDepth) || (listSize <= minElements))
@@ -403,7 +392,7 @@ OctreeNode::OctreeNode(unsigned char _depth, const Extents& exts,
     makeChildren();
 
     // non NULLs first
-    squeezeChildren (squeezed);
+    squeezeChildren(squeezed);
 
     // resize this branch cell
     resizeCell();
@@ -412,7 +401,7 @@ OctreeNode::OctreeNode(unsigned char _depth, const Extents& exts,
     if ((depth % fullListBreak) != 0)
     {
         listSize = 0;
-        free (list);
+        free(list);
         list = NULL;
     }
 
@@ -422,7 +411,7 @@ OctreeNode::OctreeNode(unsigned char _depth, const Extents& exts,
 }
 
 
-void OctreeNode::makeChildren ()
+void OctreeNode::makeChildren()
 {
     int side[3];    // the axis sides  (0 or 1)
     Extents exts;
@@ -445,13 +434,13 @@ void OctreeNode::makeChildren ()
                 // calculate the child's extents
                 for (int a = 0; a < 3; a++)
                 {
-                    exts.mins[a] = extentSet[side[a]+0][a];
-                    exts.maxs[a] = extentSet[side[a]+1][a];
+                    exts.mins[a] = extentSet[side[a] + 0][a];
+                    exts.maxs[a] = extentSet[side[a] + 1][a];
                 }
 
                 int kid = side[0] + (2 * side[1]) + (4 * side[2]);
 
-                squeezed[kid] = new OctreeNode (depth, exts, list, count);
+                squeezed[kid] = new OctreeNode(depth, exts, list, count);
 
                 if (squeezed[kid]->getCount() == 0)
                 {
@@ -459,7 +448,9 @@ void OctreeNode::makeChildren ()
                     squeezed[kid] = NULL;
                 }
                 else
+                {
                     childCount++;
+                }
                 children[kid] = squeezed[kid];
             }
         }
@@ -497,24 +488,41 @@ OctreeNode::~OctreeNode()
 {
     for (int i = 0; i < 8; i++)
         delete squeezed[i];
-    free (list);
+
+    free(list);
     return;
 }
 
-
-void OctreeNode::getFrustumList () const
+const OctreeNode* OctreeNode::getNode(unsigned char x) const
 {
-    IntersectLevel level = testAxisBoxInFrustum (extents, CullFrustum);
+    const OctreeNode* onode = children[(x)];
+    if (onode != NULL)
+        onode->getFrustumList();
+    return onode;
+}
+
+const OctreeNode* OctreeNode::getFullNode(unsigned char x) const
+{
+    const OctreeNode* onode = children[(x)];
+    if (onode != NULL)
+        onode->getFullyVisibleOcclude();
+    return onode;
+}
+
+
+void OctreeNode::getFrustumList() const
+{
+    IntersectLevel level = testAxisBoxInFrustum(extents, CullFrustum);
 
     if (level == Outside)
         return;
 
-    IntersectLevel occLevel = OcclMgr->occlude (extents, count);
+    IntersectLevel occLevel = OcclMgr->occlude(extents, count);
     if (occLevel == Contained)
         return;
 
     if ((level == Contained) && (occLevel == Outside))
-        getFullyVisible ();
+        getFullyVisible();
 
     // this cell is only partially contained within
     // the frustum and is not being fully occluded
@@ -533,53 +541,41 @@ void OctreeNode::getFrustumList () const
             if (dir[2] < 0.0f) dirbits |= (1 << 2);
             const OctreeNode* onode;
 
-#define GET_NODE(x)       \
-    onode = children[(x)];  \
-    if (onode != NULL) {    \
-      onode->getFrustumList (); \
-    }
-
-#define GET_FULL_NODE(x)      \
-    onode = children[(x)];      \
-    if (onode != NULL) {        \
-      onode->getFullyVisibleOcclude (); \
-    }
-
             if (occLevel == Outside)
             {
-                GET_NODE(dirbits);              // 0:  0,0,0
+                onode = getNode(dirbits);				// 0:  0,0,0
                 dirbits ^= (1 << 0);
-                GET_NODE(dirbits);              // 1:  1,0,0
+                onode = getNode(dirbits);				// 1:  1,0,0
                 dirbits ^= (1 << 0) | (1 << 1);
-                GET_NODE(dirbits);              // 2:  0,1,0
+                onode = getNode(dirbits);				// 2:  0,1,0
                 dirbits ^= (1 << 1) | (1 << 2);
-                GET_NODE(dirbits);              // 3:  0,0,1
+                onode = getNode(dirbits);				// 3:  0,0,1
                 dirbits ^= (1 << 0) | (1 << 1) | (1 << 2);
-                GET_NODE(dirbits);              // 4:  1,1,0
+                onode = getNode(dirbits);				// 4:  1,1,0
                 dirbits ^= (1 << 1) | (1 << 2);
-                GET_NODE(dirbits);              // 5:  1,0,1
+                onode = getNode(dirbits);				// 5:  1,0,1
                 dirbits ^= (1 << 0) | (1 << 1);
-                GET_NODE(dirbits);              // 6:  0,1,1
+                onode = getNode(dirbits);				// 6:  0,1,1
                 dirbits ^= (1 << 0);
-                GET_NODE(dirbits);              // 7:  1,1,1
+                onode = getNode(dirbits);			    // 7:  1,1,1
             }
             else
             {
-                GET_FULL_NODE(dirbits);             // 0:  0,0,0
+                onode = getFullNode(dirbits);				// 0:  0,0,0
                 dirbits ^= (1 << 0);
-                GET_FULL_NODE(dirbits);             // 1:  1,0,0
+                onode = getFullNode(dirbits);				// 1:  1,0,0
                 dirbits ^= (1 << 0) | (1 << 1);
-                GET_FULL_NODE(dirbits);             // 2:  0,1,0
+                onode = getFullNode(dirbits);				// 2:  0,1,0
                 dirbits ^= (1 << 1) | (1 << 2);
-                GET_FULL_NODE(dirbits);             // 3:  0,0,1
+                onode = getFullNode(dirbits);				// 3:  0,0,1
                 dirbits ^= (1 << 0) | (1 << 1) | (1 << 2);
-                GET_FULL_NODE(dirbits);             // 4:  1,1,0
+                onode = getFullNode(dirbits);				// 4:  1,1,0
                 dirbits ^= (1 << 1) | (1 << 2);
-                GET_FULL_NODE(dirbits);             // 5:  1,0,1
+                onode = getFullNode(dirbits);				// 5:  1,0,1
                 dirbits ^= (1 << 0) | (1 << 1);
-                GET_FULL_NODE(dirbits);             // 6:  0,1,1
+                onode = getFullNode(dirbits);				// 6:  0,1,1
                 dirbits ^= (1 << 0);
-                GET_FULL_NODE(dirbits);             // 7:  1,1,1
+                onode = getFullNode(dirbits);				// 7:  1,1,1
             }
         }
         else
@@ -587,12 +583,12 @@ void OctreeNode::getFrustumList () const
             if (occLevel == Outside)
             {
                 for (int i = 0; i < childCount; i++)
-                    squeezed[i]->getFrustumList ();
+                    squeezed[i]->getFrustumList();
             }
             else
             {
                 for (int i = 0; i < childCount; i++)
-                    squeezed[i]->getFullyVisibleOcclude ();
+                    squeezed[i]->getFullyVisibleOcclude();
             }
         }
     }
@@ -603,7 +599,7 @@ void OctreeNode::getFrustumList () const
             SceneNode* node = list[i];
             if (node->octreeState == SceneNode::OctreeCulled)
             {
-                addCullListNode (node);
+                addCullListNode(node);
                 node->octreeState = SceneNode::OctreePartial;
             }
         }
@@ -612,55 +608,55 @@ void OctreeNode::getFrustumList () const
     return;
 }
 /*
-  // FIXME - faster then the recursive version?
+// FIXME - faster then the recursive version?
 
-  static struct NodeStack {
-    OctreeNode* node;
-    int child;
-  } nodeStack[OctreeNode::maxDepth];
-  static int level;
-  static int childNum;
-  static OctreeNode* working;
+static struct NodeStack {
+OctreeNode* node;
+int child;
+} nodeStack[OctreeNode::maxDepth];
+static int level;
+static int childNum;
+static OctreeNode* working;
 
-  level = 0;
-  nodeStack[0].child = 0;
-  working = (OctreeNode*) this;
+level = 0;
+nodeStack[0].child = 0;
+working = (OctreeNode*) this;
 
-  while (level >= 0) {
-    childNum = nodeStack[level].child;
-    if (working->getChildren() > childNum) {
-      nodeStack[level].node = working;
-      nodeStack[level].child++;
-      working = working->getChild(childNum);
-      level++;
-      nodeStack[level].child = 0;
-    } else {
-      static int i;
-      for (i = 0; i < working->getListSize(); i++) {
-    static SceneNode* node;
-    node = working->getList()[i];
-    if (node->octreeState == SceneNode::OctreeCulled) {
-      addCullListNode (node);
-    }
-    node->octreeState = SceneNode::OctreeVisible;
-      }
-      level--;
-      working = nodeStack[level].node;
-    }
-  }
+while (level >= 0) {
+childNum = nodeStack[level].child;
+if (working->getChildren() > childNum) {
+nodeStack[level].node = working;
+nodeStack[level].child++;
+working = working->getChild(childNum);
+level++;
+nodeStack[level].child = 0;
+} else {
+static int i;
+for (i = 0; i < working->getListSize(); i++) {
+static SceneNode* node;
+node = working->getList()[i];
+if (node->octreeState == SceneNode::OctreeCulled) {
+addCullListNode (node);
+}
+node->octreeState = SceneNode::OctreeVisible;
+}
+level--;
+working = nodeStack[level].node;
+}
+}
 */
 
 
-void OctreeNode::getRadarList () const
+void OctreeNode::getRadarList() const
 {
-    IntersectLevel level = testAxisBoxInFrustum (extents, CullFrustum);
+    IntersectLevel level = testAxisBoxInFrustum(extents, CullFrustum);
 
     if (level == Outside)
         return;
 
     if (level == Contained)
     {
-        getFullyVisible ();
+        getFullyVisible();
         return;
     }
 
@@ -670,7 +666,7 @@ void OctreeNode::getRadarList () const
     if (childCount > 0)
     {
         for (int i = 0; i < childCount; i++)
-            squeezed[i]->getRadarList ();
+            squeezed[i]->getRadarList();
     }
     else
     {
@@ -679,7 +675,7 @@ void OctreeNode::getRadarList () const
             SceneNode* node = list[i];
             if (node->octreeState == SceneNode::OctreeCulled)
             {
-                addCullListNode (node);
+                addCullListNode(node);
                 node->octreeState = SceneNode::OctreePartial;
             }
         }
@@ -689,12 +685,12 @@ void OctreeNode::getRadarList () const
 }
 
 
-void OctreeNode::getFullyVisible () const
+void OctreeNode::getFullyVisible() const
 {
     if ((childCount > 0) && (listSize == 0))
     {
         for (int i = 0; i < childCount; i++)
-            squeezed[i]->getFullyVisible ();
+            squeezed[i]->getFullyVisible();
     }
     else
     {
@@ -703,7 +699,8 @@ void OctreeNode::getFullyVisible () const
             SceneNode* node = list[i];
             SceneNode::CullState& state = node->octreeState;
             if (state == SceneNode::OctreeCulled)
-                addCullListNode (node);
+                addCullListNode(node);
+
             state = SceneNode::OctreeVisible;
         }
     }
@@ -711,14 +708,15 @@ void OctreeNode::getFullyVisible () const
 }
 
 
-void OctreeNode::getFullyVisibleOcclude () const
+void OctreeNode::getFullyVisibleOcclude() const
 {
-    IntersectLevel occLevel = OcclMgr->occlude (extents, count);
+    IntersectLevel occLevel = OcclMgr->occlude(extents, count);
     if (occLevel == Contained)
         return;
 
+
     if (occLevel == Outside)
-        getFullyVisible ();
+        getFullyVisible();
 
     // this cell is only partially contained within
     // the frustum and is not being fully occluded
@@ -726,7 +724,7 @@ void OctreeNode::getFullyVisibleOcclude () const
     if (childCount > 0)
     {
         for (int i = 0; i < childCount; i++)
-            squeezed[i]->getFullyVisibleOcclude ();
+            squeezed[i]->getFullyVisibleOcclude();
     }
     else
     {
@@ -735,7 +733,7 @@ void OctreeNode::getFullyVisibleOcclude () const
             SceneNode* node = list[i];
             if (node->octreeState == SceneNode::OctreeCulled)
             {
-                addCullListNode (node);
+                addCullListNode(node);
                 node->octreeState = SceneNode::OctreePartial;
             }
         }
@@ -745,16 +743,16 @@ void OctreeNode::getFullyVisibleOcclude () const
 }
 
 
-void OctreeNode::getShadowList () const
+void OctreeNode::getShadowList() const
 {
-    IntersectLevel level = testAxisBoxOcclusion (extents,
-                           ShadowPlanes, ShadowCount);
+    IntersectLevel level = testAxisBoxOcclusion(extents, ShadowPlanes, ShadowCount);
+
     if (level == Outside)
         return;
 
     if (level == Contained)
     {
-        getFullyShadow ();
+        getFullyShadow();
         return;
     }
 
@@ -764,7 +762,7 @@ void OctreeNode::getShadowList () const
     if (childCount > 0)
     {
         for (int i = 0; i < childCount; i++)
-            squeezed[i]->getShadowList ();
+            squeezed[i]->getShadowList();
     }
     else
     {
@@ -773,7 +771,7 @@ void OctreeNode::getShadowList () const
             SceneNode* node = list[i];
             if (node->octreeState == SceneNode::OctreeCulled)
             {
-                addCullListNode (node);
+                addCullListNode(node);
                 node->octreeState = SceneNode::OctreePartial;
             }
         }
@@ -783,12 +781,12 @@ void OctreeNode::getShadowList () const
 }
 
 
-void OctreeNode::getFullyShadow () const
+void OctreeNode::getFullyShadow() const
 {
     if ((childCount > 0) && (listSize == 0))
     {
         for (int i = 0; i < childCount; i++)
-            squeezed[i]->getFullyShadow ();
+            squeezed[i]->getFullyShadow();
     }
     else
     {
@@ -797,7 +795,8 @@ void OctreeNode::getFullyShadow () const
             SceneNode* node = list[i];
             SceneNode::CullState& state = node->octreeState;
             if (state == SceneNode::OctreeCulled)
-                addCullListNode (node);
+                addCullListNode(node);
+
             state = SceneNode::OctreeVisible;
         }
     }
@@ -822,19 +821,21 @@ void OctreeNode::tallyStats()
             squeezed[i]->tallyStats();
     }
     else
+    {
         leafNodes++;
+    }
 
     return;
 }
 
 
-void OctreeNode::draw ()
+void OctreeNode::draw()
 {
-    GLfloat red[4] = {1.0f, 0.0f, 0.0f, 0.75f};    // red
-    GLfloat blue[4] = {0.0f, 0.0f, 1.0f, 0.75f};   // blue
-    GLfloat green[4] = {0.0f, 1.0f, 0.0f, 0.75f};  // green
-    GLfloat yellow[4] = {1.0f, 1.0f, 0.0f, 0.75f}; // yellow
-    GLfloat purple[4] = {1.0f, 0.0f, 1.0f, 0.75f}; // purple
+    GLfloat red[4] = { 1.0f, 0.0f, 0.0f, 0.75f };    // red
+    GLfloat blue[4] = { 0.0f, 0.0f, 1.0f, 0.75f };   // blue
+    GLfloat green[4] = { 0.0f, 1.0f, 0.0f, 0.75f };  // green
+    GLfloat yellow[4] = { 1.0f, 1.0f, 0.0f, 0.75f }; // yellow
+    GLfloat purple[4] = { 1.0f, 0.0f, 1.0f, 0.75f }; // purple
     GLfloat *color = purple;
     int x, y, z, c;
     float points[5][3];
@@ -843,8 +844,8 @@ void OctreeNode::draw ()
 
     if (CullFrustum != NULL)
     {
-        frustumCull = testAxisBoxInFrustum (extents, CullFrustum);
-        occludeCull = OcclMgr->occludePeek (extents);
+        frustumCull = testAxisBoxInFrustum(extents, CullFrustum);
+        occludeCull = OcclMgr->occludePeek(extents);
     }
 
     // choose the color
@@ -866,7 +867,7 @@ void OctreeNode::draw ()
             color = yellow;
         break;
     }
-    glColor4fv (color);
+    glColor4fv(color);
 
     const float* exts[2] = { extents.mins, extents.maxs };
 
@@ -881,11 +882,13 @@ void OctreeNode::draw ()
             points[c][1] = exts[y][1];
             points[c][2] = exts[z][2];
         }
-        memcpy (points[4], points[0], sizeof (points[4]));
-        glBegin (GL_LINE_STRIP);
+        memcpy(points[4], points[0], sizeof(points[4]));
+        glBegin(GL_LINE_STRIP);
+
         for (int i = 0; i < 5; i++)
-            glVertex3fv (points[i]);
-        glEnd ();
+            glVertex3fv(points[i]);
+
+        glEnd();
     }
 
     // draw the corner edges
@@ -899,15 +902,15 @@ void OctreeNode::draw ()
             points[z][1] = exts[y][1];
             points[z][2] = exts[z][2];
         }
-        glBegin (GL_LINE_STRIP);
-        glVertex3fv (points[0]);
-        glVertex3fv (points[1]);
-        glEnd ();
+        glBegin(GL_LINE_STRIP);
+        glVertex3fv(points[0]);
+        glVertex3fv(points[1]);
+        glEnd();
     }
 
     // draw the kids
     for (c = 0; c < childCount; c++)
-        squeezed[c]->draw ();
+        squeezed[c]->draw();
 
     return;
 }
@@ -915,7 +918,7 @@ void OctreeNode::draw ()
 
 // Local Variables: ***
 // mode: C++ ***
-// tab-width: 4***
+// tab-width: 4 ***
 // c-basic-offset: 4 ***
 // indent-tabs-mode: nil ***
 // End: ***

--- a/src/scene/Octree.h
+++ b/src/scene/Octree.h
@@ -104,6 +104,9 @@ private:
     int count;  // number of nodes in this and subnodes
     int listSize;
     SceneNode** list;
+
+    const OctreeNode* getNode(unsigned char x) const;
+    const OctreeNode* getFullNode(unsigned char x) const;
 };
 
 


### PR DESCRIPTION
convert inline macros into actual functions, so that astyle won't screw everything over.