### PR TITLE
vary the heights of the random worlds by less than the max bump height

### DIFF
--- a/src/bzfs/WorldGenerators.cxx
+++ b/src/bzfs/WorldGenerators.cxx
@@ -52,12 +52,16 @@ WorldInfo *defineRandomWorld()
     // make boxes
     int i;
     float boxHeight = BZDB.eval(StateDatabase::BZDB_BOXHEIGHT);
+    float heightJitter = BZDB.eval(StateDatabase::BZDB_MAXBUMPHEIGHT) * 0.45f; // jiggle the heights by less than the max bump, to help z fighting and allow textures to be alligned
     float h = boxHeight;
     const int numBoxes = int((0.5f + 0.7f * bzfrand()) * actCitySize * actCitySize);
     for (i = 0; i < numBoxes; i++)
     {
         if (clOptions->randomHeights)
             h = boxHeight * ( 2.0f * (float)bzfrand() + 0.5f);
+        else
+            h = boxHeight + (((2.0f * (float)bzfrand()) - 1.0f) * heightJitter);
+
         myWorld->addBox(worldSize * ((float)bzfrand() - 0.5f),
                         worldSize * ((float)bzfrand() - 0.5f),
                         0.0f, (float)(2.0 * M_PI * bzfrand()),


### PR DESCRIPTION
… to give a little variation in the geometry.

Also allows the roof texture to stay oriented with the box.