### PR TITLE
don't pass the file by ref, gcc doesn't keep the temps around long en…

### DIFF
--- a/include/TextureManager.h
+++ b/include/TextureManager.h
@@ -91,7 +91,7 @@ private:
     int addTexture( const char*, OpenGLTexture *texture );
     OpenGLTexture* loadTexture( FileTextureInit &init, bool reportFail = true );
 
-    int tryLoadTexture(OSFile &osFilename, const char* name, bool reportFail);
+    int tryLoadTexture(OSFile osFilename, const char* name, bool reportFail);
 
     typedef std::map<std::string, ImageInfo> TextureNameMap;
     typedef std::map<int, ImageInfo*> TextureIDMap;

--- a/src/3D/TextureManager.cxx
+++ b/src/3D/TextureManager.cxx
@@ -72,7 +72,7 @@ TextureManager::~TextureManager()
     textureIDs.clear();
 }
 
-int TextureManager::tryLoadTexture(OSFile &osFilename, const char* name, bool reportFail)
+int TextureManager::tryLoadTexture(OSFile osFilename, const char* name, bool reportFail)
 {
     const std::string filename = osFilename.getOSName();
 


### PR DESCRIPTION
…ough and produces an error.