### PR TITLE
Decouple flag from effect to allow more custom flag options

### DIFF
--- a/include/Flag.h
+++ b/include/Flag.h
@@ -57,6 +57,52 @@
 #include "global.h"
 #include "Address.h"
 
+enum class FlagEffect
+{
+    Normal,
+    Velocity,
+    QuickTurn,
+    OscillationOverthruster,
+    RapidFire,
+    MachineGun,
+    GuidedMissile,
+    Laser,
+    Ricochet,
+    SuperBullet,
+    InvisibleBullet,
+    Stealth,
+    Tiny,
+    Narrow,
+    Shield,
+    Steamroller,
+    ShockWave,
+    PhantomZone,
+    Jumping,
+    Identify,
+    Cloaking,
+    Useless,
+    Masquerade,
+    Seer,
+    Thief,
+    Burrow,
+    Wings,
+    Agility,
+    Colorblindness,
+    Obesity,
+    LeftTurnOnly,
+    RightTurnOnly,
+    ForwardOnly,
+    ReverseOnly,
+    Momentum,
+    Blindness,
+    Jamming,
+    WideAngle,
+    NoJumping,
+    TriggerHappy,
+    ReverseControls,
+    Bouncy,
+    NoShot,
+};
 
 /** This enum says where a flag is. */
 enum class FlagStatus
@@ -117,7 +163,7 @@ public:
     typedef std::set<FlagType::Ptr> Set;
 
     FlagType( const std::string& name, const std::string& abbv, FlagEndurance _endurance,
-              ShotType sType, FlagQuality quality, TeamColor team, const std::string& help,
+              ShotType sType, FlagQuality quality, TeamColor team, FlagEffect effect, const std::string& help,
               bool _custom = false ) :
         flagName(name),
         flagAbbv(abbv),
@@ -127,6 +173,7 @@ public:
         flagShot = sType;
         flagQuality = quality;
         flagTeam = team;
+        flagEffect = effect;
         custom = _custom;
     }
 
@@ -168,6 +215,7 @@ public:
     FlagQuality flagQuality;
     ShotType flagShot;
     TeamColor flagTeam;
+    FlagEffect flagEffect = FlagEffect::Normal;
     bool custom;
 
     static std::vector<Set> Sets;

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -2496,7 +2496,7 @@ enum class bz_FlagEffect
     NoShot,
 };
 
-BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name, char* helpString, bz_eFlagQuality quality = bz_eFlagQuality::Good, bz_FlagEffect effect = bz_FlagEffect::Normal, bz_eTeamType teamColor = eNoTeam);
+BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name, const char* helpString, bz_eFlagQuality quality = bz_eFlagQuality::Good, bz_FlagEffect effect = bz_FlagEffect::Normal, bz_eTeamType teamColor = eNoTeam);
 
 // utility
 BZF_API const char* bz_MD5(const char * str);

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -104,13 +104,6 @@ inline To force_cast(From const & f)
 #  endif
 #endif
 
-typedef enum
-{
-    eGoodFlag = 0,
-    eBadFlag,
-    eLastFlagQuality
-} bz_eFlagQuality;
-
 //utility classes
 class BZF_API bz_ApiString
 {
@@ -2445,15 +2438,65 @@ BZF_API int bz_addServerSidePlayer(bz_ServerSidePlayerHandler *handler);
 BZF_API bool bz_removeServerSidePlayer(int playerID,
                                        bz_ServerSidePlayerHandler *handler); // you have to pass in the handler to ensure you "own" the player
 
-// no ShotType support in 2.4 (yet?).  still accept the ShotType parameter for compatibility.
-typedef int bz_eShotType;
-
 // Note: there is NO bz_UnregisterCustomFlag, 'cause that would jack up connected clients.
 // If you really need to unregister a flag, shut down the server.
-BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name,
-                                   const char* helpString, bz_eShotType shotType,
-                                   bz_eFlagQuality quality);
+/*DEPRECATED*/ BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name, const char* helpString, int shotType, uint8_t quality);
 
+enum class bz_eFlagQuality
+{
+    Good = 0,
+    Bad,
+    Last
+};
+
+enum class bz_FlagEffect
+{
+    Normal,
+    Velocity,
+    QuickTurn,
+    OscillationOverthruster,
+    RapidFire,
+    MachineGun,
+    GuidedMissile,
+    Laser,
+    Ricochet,
+    SuperBullet,
+    InvisibleBullet,
+    Stealth,
+    Tiny,
+    Narrow,
+    Shield,
+    Steamroller,
+    ShockWave,
+    PhantomZone,
+    Jumping,
+    Identify,
+    Cloaking,
+    Useless,
+    Masquerade,
+    Seer,
+    Thief,
+    Burrow,
+    Wings,
+    Agility,
+    Colorblindness,
+    Obesity,
+    LeftTurnOnly,
+    RightTurnOnly,
+    ForwardOnly,
+    ReverseOnly,
+    Momentum,
+    Blindness,
+    Jamming,
+    WideAngle,
+    NoJumping,
+    TriggerHappy,
+    ReverseControls,
+    Bouncy,
+    NoShot,
+};
+
+BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name, char* helpString, bz_eFlagQuality quality = bz_eFlagQuality::Good, bz_FlagEffect effect = bz_FlagEffect::Normal, bz_eTeamType teamColor = eNoTeam);
 
 // utility
 BZF_API const char* bz_MD5(const char * str);

--- a/plugins/customflagsample/customflagsample.cpp
+++ b/plugins/customflagsample/customflagsample.cpp
@@ -21,7 +21,7 @@ void CustomFlagSample::Init ( const char* /*commandLine*/ )
   bz_debugMessage(4, "customflagsample plugin loaded");
 
   // register our special custom flag
-  bz_RegisterCustomFlag("CF", "Custom Flag", "A simple sample custom flag from the customflagsample plugin", /*eSuperShot*/0, eGoodFlag);
+  bz_RegisterCustomFlag("CF", "Custom Flag", "A simple sample custom flag from the customflagsample plugin");
 
   // register events for pick up, drop, transfer, and fire
   Register(bz_eFlagTransferredEvent);

--- a/plugins/genocide/genocide.cpp
+++ b/plugins/genocide/genocide.cpp
@@ -21,7 +21,7 @@ void genocide::Init ( const char* /*commandLine*/ )
   bz_debugMessage(4, "genocide plugin loaded");
 
   // register our special custom flag
-  bz_RegisterCustomFlag("G", "Genocide", "Killing one tank kills that tank's whole team.", /*eSuperShot*/0, eGoodFlag);
+  bz_RegisterCustomFlag("G", "Genocide", "Killing one tank kills that tank's whole team.");
 
   // register events for pick up, drop, transfer, and fire
   Register(bz_eFlagTransferredEvent);

--- a/src/bzflag/AutoPilot.cxx
+++ b/src/bzflag/AutoPilot.cxx
@@ -99,18 +99,15 @@ static ShotPath::Ptr findWorstBullet(float &minDistance)
             if (shot == nullptr || shot->isExpired())
                 continue;
 
-            if ((shot->getFlag() == Flags::InvisibleBullet) &&
-                    (myTank->getFlag() != Flags::Seer))
+            if ((shot->getFlag()->flagEffect == FlagEffect::InvisibleBullet) && (myTank->getFlag()->flagEffect != FlagEffect::Seer))
                 continue; //Theoretically Roger could triangulate the sound
             if (remotePlayers[t]->isPhantomZoned() && !myTank->isPhantomZoned())
                 continue;
-            if ((shot->getFlag() == Flags::Laser) &&
-                    (myTank->getFlag() == Flags::Cloaking))
+            if ((shot->getFlag()->flagEffect == FlagEffect::Laser) && (myTank->getFlag()->flagEffect == FlagEffect::Cloaking))
                 continue; //cloaked tanks can't die from lasers
 
             const float* shotPos = shot->getPosition();
-            if ((fabs(shotPos[2] - pos[2]) > BZDBCache::tankHeight) &&
-                    (shot->getFlag() != Flags::GuidedMissile))
+            if ((fabs(shotPos[2] - pos[2]) > BZDBCache::tankHeight) && (shot->getFlag()->flagEffect != FlagEffect::GuidedMissile))
                 continue;
 
             const float dist = TargetingUtils::getTargetDistance(pos, shotPos);
@@ -140,13 +137,13 @@ static ShotPath::Ptr findWorstBullet(float &minDistance)
         if (shot == nullptr|| shot->isExpired())
             continue;
 
-        if (shot->getFlag() == Flags::InvisibleBullet && myTank->getFlag() != Flags::Seer)
+        if (shot->getFlag()->flagEffect == FlagEffect::InvisibleBullet && myTank->getFlag()->flagEffect != FlagEffect::Seer)
             continue; //Theoretically Roger could triangulate the sound
-        if (shot->getFlag() == Flags::Laser && myTank->getFlag() == Flags::Cloaking)
+        if (shot->getFlag()->flagEffect == FlagEffect::Laser && myTank->getFlag()->flagEffect == FlagEffect::Cloaking)
             continue; //cloaked tanks can't die from lasers
 
         const float* shotPos = shot->getPosition();
-        if ((fabs(shotPos[2] - pos[2]) > BZDBCache::tankHeight) && (shot->getFlag() != Flags::GuidedMissile))
+        if ((fabs(shotPos[2] - pos[2]) > BZDBCache::tankHeight) && (shot->getFlag()->flagEffect != FlagEffect::GuidedMissile))
             continue;
 
         const float dist = TargetingUtils::getTargetDistance( pos, shotPos );
@@ -210,7 +207,7 @@ static bool avoidBullet(float &rotation, float &speed)
     LocalPlayer *myTank = LocalPlayer::getMyTank();
     const float *pos = myTank->getPosition();
 
-    if ((myTank->getFlag() == Flags::Narrow) || (myTank->getFlag() == Flags::Burrow))
+    if ((myTank->getFlag()->flagEffect == FlagEffect::Narrow) || (myTank->getFlag()->flagEffect == FlagEffect::Burrow))
         return false; // take our chances
 
     float minDistance;
@@ -227,13 +224,13 @@ static bool avoidBullet(float &rotation, float &speed)
     float trueVec[2] = {(pos[0]-shotPos[0])/minDistance,(pos[1]-shotPos[1])/minDistance};
     float dotProd = trueVec[0]*shotUnitVec[0]+trueVec[1]*shotUnitVec[1];
 
-    if (((World::getWorld()->allowJumping() || (myTank->getFlag()) == Flags::Jumping
-            || (myTank->getFlag()) == Flags::Wings))
+    if (((World::getWorld()->allowJumping() || myTank->getFlag()->flagEffect == FlagEffect::Jumping
+            || (myTank->getFlag())->flagEffect == FlagEffect::Wings))
             && (minDistance < ( std::max(dotProd, 0.5f) * BZDBCache::tankLength * 2.25f))
-            && (myTank->getFlag() != Flags::NoJumping))
+            && (myTank->getFlag()->flagEffect != FlagEffect::NoJumping))
     {
         wantJump = true;
-        return (myTank->getFlag() != Flags::Wings);
+        return (myTank->getFlag()->flagEffect != FlagEffect::Wings);
     }
     else if (dotProd > 0.96f)
     {
@@ -293,7 +290,7 @@ static bool stuckOnWall(float &rotation, float &speed)
     const float *pos = myTank->getPosition();
     float myAzimuth = myTank->getAngle();
 
-    const bool phased = (myTank->getFlag() == Flags::OscillationOverthruster)
+    const bool phased = (myTank->getFlag()->flagEffect == FlagEffect::OscillationOverthruster)
                         || myTank->isPhantomZoned();
 
     if (!phased && (TargetingUtils::getOpenDistance(pos, myAzimuth) < 5.0f))
@@ -341,20 +338,20 @@ static RemotePlayer *findBestTarget()
         {
 
             if (remotePlayers[t]->isPhantomZoned() && !myTank->isPhantomZoned()
-                    && (myTank->getFlag() != Flags::ShockWave)
-                    && (myTank->getFlag() != Flags::SuperBullet))
+                    && (myTank->getFlag()->flagEffect != FlagEffect::ShockWave)
+                    && (myTank->getFlag()->flagEffect != FlagEffect::SuperBullet))
                 continue;
 
-            if ((remotePlayers[t]->getFlag() == Flags::Cloaking) &&
-                    (myTank->getFlag() == Flags::Laser))
+            if ((remotePlayers[t]->getFlag()->flagEffect == FlagEffect::Cloaking) &&
+                    (myTank->getFlag()->flagEffect == FlagEffect::Laser))
                 continue;
 
             //perform a draft that has us chase the proposed opponent if they have our flag
             if (World::getWorld()->allowTeamFlags() &&
-                    (((myTank->getTeam() == RedTeam) && (remotePlayers[t]->getFlag() == Flags::RedTeam)) ||
-                     ((myTank->getTeam() == GreenTeam) && (remotePlayers[t]->getFlag() == Flags::GreenTeam)) ||
-                     ((myTank->getTeam() == BlueTeam) && (remotePlayers[t]->getFlag() == Flags::BlueTeam)) ||
-                     ((myTank->getTeam() == PurpleTeam) && (remotePlayers[t]->getFlag() == Flags::PurpleTeam))))
+                    (((myTank->getTeam() == RedTeam) && (remotePlayers[t]->getFlag()->flagTeam == RedTeam)) ||
+                     ((myTank->getTeam() == GreenTeam) && (remotePlayers[t]->getFlag()->flagTeam == GreenTeam)) ||
+                     ((myTank->getTeam() == BlueTeam) && (remotePlayers[t]->getFlag()->flagTeam == BlueTeam)) ||
+                     ((myTank->getTeam() == PurpleTeam) && (remotePlayers[t]->getFlag()->flagTeam == PurpleTeam))))
             {
                 target = remotePlayers[t];
                 break;
@@ -367,8 +364,8 @@ static RemotePlayer *findBestTarget()
 
             if (d < distance)
             {
-                if ((remotePlayers[t]->getFlag() != Flags::Stealth)
-                        ||  (myTank->getFlag() == Flags::Seer)
+                if ((remotePlayers[t]->getFlag()->flagEffect != FlagEffect::Stealth)
+                        ||  (myTank->getFlag()->flagEffect == FlagEffect::Seer)
                         ||  ((!isObscured) &&
                              (TargetingUtils::getTargetAngleDifference(pos, myAzimuth, remotePlayers[t]->getPosition()) <= 30.0f)))
                 {
@@ -424,7 +421,7 @@ static bool chasePlayer(float &rotation, float &speed)
 
         building = ShotStrategy::getFirstBuilding(tankRay, -0.5f, d);
         if (building && !myTank->isPhantomZoned() &&
-                (myTank->getFlag() != Flags::OscillationOverthruster))
+                (myTank->getFlag()->flagEffect != FlagEffect::OscillationOverthruster))
         {
             //If roger can drive around it, just do that
 
@@ -485,7 +482,7 @@ static bool chasePlayer(float &rotation, float &speed)
             speed = 1.0;
         }
     }
-    else if (target->getFlag() != Flags::Burrow)
+    else if (target->getFlag()->flagEffect != FlagEffect::Burrow)
     {
         speed = -0.5f;
         rotation *= (float)(M_PI / (2.0 * fabs(rotation)));
@@ -626,7 +623,7 @@ static bool navigate(float &rotation, float &speed)
     else
         speed = 1.0f;
     if (myTank->getLocation() == LocalPlayer::InAir
-            && myTank->getFlag() == Flags::Wings)
+            && myTank->getFlag()->flagEffect == FlagEffect::Wings)
         wantJump = true;
 
     navRot = rotation;
@@ -650,7 +647,7 @@ static bool fireAtTank()
     Ray tankRay(pos, dir);
     pos[2] -= myTank->getMuzzleHeight();
 
-    if (myTank->getFlag() == Flags::ShockWave)
+    if (myTank->getFlag()->flagEffect == FlagEffect::ShockWave)
     {
         TimeKeeper now = TimeKeeper::getTick();
         if (now - lastShot >= (1.0f / World::getWorld()->getMaxShots()))
@@ -712,8 +709,8 @@ static bool fireAtTank()
                 {
 
                     if (remotePlayers[t]->isPhantomZoned() && !myTank->isPhantomZoned()
-                            && (myTank->getFlag() != Flags::SuperBullet)
-                            && (myTank->getFlag() != Flags::ShockWave))
+                            && (myTank->getFlag()->flagEffect != FlagEffect::SuperBullet)
+                            && (myTank->getFlag()->flagEffect != FlagEffect::ShockWave))
                         continue;
 
                     const float *tp = remotePlayers[t]->getPosition();
@@ -729,7 +726,7 @@ static bool fireAtTank()
 
                     float dist = TargetingUtils::getTargetDistance( pos, enemyPos );
 
-                    if ((myTank->getFlag() == Flags::GuidedMissile) || (fabs(pos[2] - enemyPos[2]) < 2.0f * BZDBCache::tankHeight))
+                    if ((myTank->getFlag()->flagEffect == FlagEffect::GuidedMissile) || (fabs(pos[2] - enemyPos[2]) < 2.0f * BZDBCache::tankHeight))
                     {
 
                         float targetDiff = TargetingUtils::getTargetAngleDifference(pos, myAzimuth, enemyPos );
@@ -737,7 +734,7 @@ static bool fireAtTank()
                                 ||  ((dist < (2.0f * BZDB.eval(StateDatabase::BZDB_SHOTSPEED))) && (targetDiff < closeErrorLimit)))
                         {
                             bool isTargetObscured;
-                            if (myTank->getFlag() != Flags::SuperBullet)
+                            if (myTank->getFlag()->flagEffect != FlagEffect::SuperBullet)
                                 isTargetObscured = TargetingUtils::isLocationObscured( pos, enemyPos );
                             else
                                 isTargetObscured = false;
@@ -763,10 +760,10 @@ static void dropHardFlags()
 {
     LocalPlayer *myTank = LocalPlayer::getMyTank();
     FlagType::Ptr type = myTank->getFlag();
-    if ((type == Flags::Useless)
-            ||  (type == Flags::MachineGun)
-            ||  (type == Flags::Identify)
-            ||  ((type == Flags::PhantomZone) && !myTank->isFlagActive()))
+    if ((type->flagEffect == FlagEffect::Useless)
+            ||  (type->flagEffect == FlagEffect::MachineGun)
+            ||  (type->flagEffect == FlagEffect::Identify)
+            ||  ((type->flagEffect == FlagEffect::PhantomZone) && !myTank->isFlagActive()))
     {
         serverLink->sendDropFlag(myTank->getPosition());
         handleFlagDropped(myTank);

--- a/src/bzflag/BaseLocalPlayer.cxx
+++ b/src/bzflag/BaseLocalPlayer.cxx
@@ -94,9 +94,9 @@ void BaseLocalPlayer::update(float inputDT)
 
         // expand bounding box to include entire tank
         float size = BZDBCache::tankRadius;
-        if (getFlag() == Flags::Obesity) size *= BZDB.eval(StateDatabase::BZDB_OBESEFACTOR);
-        else if (getFlag() == Flags::Tiny) size *= BZDB.eval(StateDatabase::BZDB_TINYFACTOR);
-        else if (getFlag() == Flags::Thief) size *= BZDB.eval(StateDatabase::BZDB_THIEFTINYFACTOR);
+        if (getFlag()->flagEffect == FlagEffect::Obesity) size *= BZDB.eval(StateDatabase::BZDB_OBESEFACTOR);
+        else if (getFlag()->flagEffect == FlagEffect::Tiny) size *= BZDB.eval(StateDatabase::BZDB_TINYFACTOR);
+        else if (getFlag()->flagEffect == FlagEffect::Thief) size *= BZDB.eval(StateDatabase::BZDB_THIEFTINYFACTOR);
         bbox[0][0] -= size;
         bbox[1][0] += size;
         bbox[0][1] -= size;

--- a/src/bzflag/GuidedMissleStrategy.cxx
+++ b/src/bzflag/GuidedMissleStrategy.cxx
@@ -164,7 +164,7 @@ void GuidedMissileStrategy::update(float dt)
         }
     }
 
-    if ((target != NULL) && ((target->getFlag() == Flags::Stealth)  || ((target->getStatus() & short(PlayerState::Alive)) == 0)))
+    if ((target != NULL) && ((target->getFlag()->flagEffect == FlagEffect::Stealth)  || ((target->getStatus() & short(PlayerState::Alive)) == 0)))
     {
         target = NULL;
         lastTarget = NoPlayer;
@@ -357,7 +357,7 @@ float GuidedMissileStrategy::checkHit(const BaseLocalPlayer* tank, float positio
 
         // get closest approach time
         float t;
-        if (tank->getFlag() == Flags::Narrow)
+        if (tank->getFlag()->flagEffect == FlagEffect::Narrow)
         {
             // find closest approach to narrow box around tank.  width of box
             // is shell radius so you can actually hit narrow tank head on.

--- a/src/bzflag/LocalPlayer.cxx
+++ b/src/bzflag/LocalPlayer.cxx
@@ -1221,8 +1221,8 @@ bool LocalPlayer::fireShot()
     // prepare shot
     FiringInfo firingInfo(*this, localShotID);
     firingInfo.shot.id = 0xFFFF; // always set the GUID to invalid, server will set it on return
-    // FIXME team coloring of shot is never used; it was meant to be used
-    // for rabbit mode to correctly calculate team kills when rabbit changes
+                                 // FIXME team coloring of shot is never used; it was meant to be used
+                                 // for rabbit mode to correctly calculate team kills when rabbit changes
     firingInfo.shot.team = getTeam();
     if (firingInfo.flagType->flagEffect == FlagEffect::ShockWave)
     {
@@ -1254,11 +1254,16 @@ bool LocalPlayer::fireShot()
         if (!BZDB.isTrue(StateDatabase::BZDB_SHOTSKEEPVERTICALV)) firingInfo.shot.vel[2] = 0.0f;
     }
 
-    // make shot and put it in the table
-    ShotPath::Ptr shot = ShotPath::Create(firingInfo);
-    shot->sendUpdates = true;
-    localShots.push_back(shot);
-    addShotToSlot(shot); // track the reload in the slot
+    if (getFlag()->flagEffect != FlagEffect::NoShot)
+    {
+        // make shot and put it in the table
+        ShotPath::Ptr shot = ShotPath::Create(firingInfo);
+        shot->sendUpdates = true;
+        localShots.push_back(shot);
+        addShotToSlot(shot); // track the reload in the slot
+    }
+    else
+        addEmptyShotToSlot(localShotID); // make the reload timer do what the reload timer would normal do
 
     // Insert timestamp, useful for dead reckoning jitter fixing
     // TODO should maybe use getTick() instead? must double check

--- a/src/bzflag/Plan.cxx
+++ b/src/bzflag/Plan.cxx
@@ -57,7 +57,7 @@ void Plan::execute(float &, float &)
     Ray tankRay(pos, dir);
     pos[2] -= myTank->getMuzzleHeight();
 
-    if (myTank->getFlag() == Flags::ShockWave)
+    if (myTank->getFlag()->flagEffect == FlagEffect::ShockWave)
     {
         TimeKeeper now = TimeKeeper::getTick();
         if (now - lastShot >= (1.0f / World::getWorld()->getMaxShots()))
@@ -120,7 +120,7 @@ void Plan::execute(float &, float &)
                 {
 
                     if (remotePlayers[t]->isPhantomZoned() && !myTank->isPhantomZoned()
-                            && (myTank->getFlag() != Flags::SuperBullet))
+                            && (myTank->getFlag()->flagEffect != FlagEffect::SuperBullet))
                         continue;
 
                     const float *tp = remotePlayers[t]->getPosition();
@@ -136,7 +136,7 @@ void Plan::execute(float &, float &)
 
                     float dist = TargetingUtils::getTargetDistance( pos, enemyPos );
 
-                    if ((myTank->getFlag() == Flags::GuidedMissile) || (fabs(pos[2] - enemyPos[2]) < 2.0f * BZDBCache::tankHeight))
+                    if ((myTank->getFlag()->flagEffect == FlagEffect::GuidedMissile) || (fabs(pos[2] - enemyPos[2]) < 2.0f * BZDBCache::tankHeight))
                     {
 
                         float targetDiff = TargetingUtils::getTargetAngleDifference(pos, myAzimuth, enemyPos );
@@ -144,7 +144,7 @@ void Plan::execute(float &, float &)
                                 ||  ((dist < (2.0f * BZDB.eval(StateDatabase::BZDB_SHOTSPEED))) && (targetDiff < closeErrorLimit)))
                         {
                             bool isTargetObscured;
-                            if (myTank->getFlag() != Flags::SuperBullet)
+                            if (myTank->getFlag()->flagEffect != FlagEffect::SuperBullet)
                                 isTargetObscured = TargetingUtils::isLocationObscured( pos, enemyPos );
                             else
                                 isTargetObscured = false;
@@ -168,7 +168,7 @@ bool Plan::avoidBullet(float &rotation, float &speed)
     LocalPlayer *myTank = LocalPlayer::getMyTank();
     const float *pos = myTank->getPosition();
 
-    if ((myTank->getFlag() == Flags::Narrow) || (myTank->getFlag() == Flags::Burrow))
+    if ((myTank->getFlag()->flagEffect == FlagEffect::Narrow) || (myTank->getFlag()->flagEffect == FlagEffect::Burrow))
         return false; // take our chances
 
     float minDistance;
@@ -185,13 +185,13 @@ bool Plan::avoidBullet(float &rotation, float &speed)
     float trueVec[2] = {(pos[0]-shotPos[0])/minDistance,(pos[1]-shotPos[1])/minDistance};
     float dotProd = trueVec[0]*shotUnitVec[0]+trueVec[1]*shotUnitVec[1];
 
-    if (((World::getWorld()->allowJumping() || (myTank->getFlag()) == Flags::Jumping
-            || (myTank->getFlag()) == Flags::Wings))
+    if (((World::getWorld()->allowJumping() || (myTank->getFlag())->flagEffect == FlagEffect::Jumping
+            || (myTank->getFlag())->flagEffect == FlagEffect::Wings))
             && (minDistance < (std::max(dotProd,0.5f) * BZDBCache::tankLength * 2.25f))
-            && (myTank->getFlag() != Flags::NoJumping))
+            && (myTank->getFlag()->flagEffect != FlagEffect::NoJumping))
     {
         myTank->setJump();
-        return (myTank->getFlag() != Flags::Wings);
+        return (myTank->getFlag()->flagEffect != FlagEffect::Wings);
     }
     else if (dotProd > 0.96f)
     {
@@ -246,18 +246,18 @@ ShotPath::Ptr   Plan::findWorstBullet(float &minDistance)
             if (!shot || shot->isExpired())
                 continue;
 
-            if ((shot->getFlag() == Flags::InvisibleBullet) &&
-                    (myTank->getFlag() != Flags::Seer))
+            if ((shot->getFlag()->flagEffect == FlagEffect::InvisibleBullet) &&
+                    (myTank->getFlag()->flagEffect != FlagEffect::Seer))
                 continue; //Theoretically Roger could triangulate the sound
             if (remotePlayers[t]->isPhantomZoned() && !myTank->isPhantomZoned())
                 continue;
-            if ((shot->getFlag() == Flags::Laser) &&
-                    (myTank->getFlag() == Flags::Cloaking))
+            if ((shot->getFlag()->flagEffect == FlagEffect::Laser) &&
+                    (myTank->getFlag()->flagEffect == FlagEffect::Cloaking))
                 continue; //cloaked tanks can't die from lasers
 
             const float* shotPos = shot->getPosition();
             if ((fabs(shotPos[2] - pos[2]) > BZDBCache::tankHeight) &&
-                    (shot->getFlag() != Flags::GuidedMissile))
+                    (shot->getFlag()->flagEffect != FlagEffect::GuidedMissile))
                 continue;
 
             const float dist = TargetingUtils::getTargetDistance(pos, shotPos);
@@ -286,13 +286,13 @@ ShotPath::Ptr   Plan::findWorstBullet(float &minDistance)
         if (!shot || shot->isExpired())
             continue;
 
-        if (shot->getFlag() == Flags::InvisibleBullet && myTank->getFlag() != Flags::Seer)
+        if (shot->getFlag()->flagEffect == FlagEffect::InvisibleBullet && myTank->getFlag()->flagEffect != FlagEffect::Seer)
             continue; //Theoretically Roger could triangulate the sound
-        if (shot->getFlag() == Flags::Laser && myTank->getFlag() == Flags::Cloaking)
+        if (shot->getFlag()->flagEffect == FlagEffect::Laser && myTank->getFlag()->flagEffect == FlagEffect::Cloaking)
             continue; //cloaked tanks can't die from lasers
 
         const float* shotPos = shot->getPosition();
-        if ((fabs(shotPos[2] - pos[2]) > BZDBCache::tankHeight) && (shot->getFlag() != Flags::GuidedMissile))
+        if ((fabs(shotPos[2] - pos[2]) > BZDBCache::tankHeight) && (shot->getFlag()->flagEffect != FlagEffect::GuidedMissile))
             continue;
 
         const float dist = TargetingUtils::getTargetDistance( pos, shotPos );

--- a/src/bzflag/Player.cxx
+++ b/src/bzflag/Player.cxx
@@ -275,9 +275,9 @@ float Player::getMaxSpeed ( void ) const
     // BURROW and AGILITY will not be taken into account
     const FlagType::Ptr flag = getFlag();
     float maxSpeed = BZDBCache::tankSpeed;
-    if (flag == Flags::Velocity)
+    if (flag->flagEffect == FlagEffect::Velocity)
         maxSpeed *= BZDB.eval(StateDatabase::BZDB_VELOCITYAD);
-    else if (flag == Flags::Thief)
+    else if (flag->flagEffect == FlagEffect::Thief)
         maxSpeed *= BZDB.eval(StateDatabase::BZDB_THIEFVELAD);
     return maxSpeed;
 }
@@ -371,7 +371,7 @@ void Player::setPhysicsDriver(int driver)
 void Player::setRelativeMotion()
 {
     bool falling = (state.status & short(PlayerState::Falling)) != 0;
-    if (falling && (getFlag() != Flags::Wings))
+    if (falling && (getFlag()->flagEffect != FlagEffect::Wings))
     {
         // no adjustments while falling
         return;
@@ -501,7 +501,7 @@ void Player::updateTank(float dt, bool local)
 void Player::updateJumpJets(float dt)
 {
     float jumpVel;
-    if (getFlag() == Flags::Wings)
+    if (getFlag()->flagEffect == FlagEffect::Wings)
         jumpVel = BZDB.eval(StateDatabase::BZDB_WINGSJUMPVELOCITY);
     else
         jumpVel = BZDB.eval(StateDatabase::BZDB_JUMPVELOCITY);
@@ -812,25 +812,25 @@ void Player::updateFlagEffect(FlagType::Ptr effectFlag)
     dimensionsTarget[0] = 1.0f;
     dimensionsTarget[1] = 1.0f;
     dimensionsTarget[2] = 1.0f;
-    if (effectFlag == Flags::Obesity)
+    if (effectFlag->flagEffect == FlagEffect::Obesity)
     {
         const float factor = BZDB.eval(StateDatabase::BZDB_OBESEFACTOR);
         dimensionsTarget[0] = factor;
         dimensionsTarget[1] = factor;
     }
-    else if (effectFlag == Flags::Tiny)
+    else if (effectFlag->flagEffect == FlagEffect::Tiny)
     {
         const float factor = BZDB.eval(StateDatabase::BZDB_TINYFACTOR);
         dimensionsTarget[0] = factor;
         dimensionsTarget[1] = factor;
     }
-    else if (effectFlag == Flags::Thief)
+    else if (effectFlag->flagEffect == FlagEffect::Thief)
     {
         const float factor = BZDB.eval(StateDatabase::BZDB_THIEFTINYFACTOR);
         dimensionsTarget[0] = factor;
         dimensionsTarget[1] = factor;
     }
-    else if (effectFlag == Flags::Narrow)
+    else if (effectFlag->flagEffect == FlagEffect::Narrow)
         dimensionsTarget[1] = 0.001f;
 
     // set the dimension rates
@@ -844,7 +844,7 @@ void Player::updateFlagEffect(FlagType::Ptr effectFlag)
     }
 
     // set the alpha target
-    if (effectFlag == Flags::Cloaking)
+    if (effectFlag->flagEffect == FlagEffect::Cloaking)
         alphaTarget = 0.0f;
     else
         alphaTarget = 1.0f;
@@ -982,15 +982,15 @@ void Player::addToScene(SceneDatabase* scene, TeamColor effectiveTeam,
         tankNode->setDimensions(dimensionsScale);
     else
     {
-        if (flagType == Flags::Obesity) tankNode->setObese();
-        else if (flagType == Flags::Tiny) tankNode->setTiny();
-        else if (flagType == Flags::Narrow) tankNode->setNarrow();
-        else if (flagType == Flags::Thief) tankNode->setThief();
+        if (flagType->flagEffect == FlagEffect::Obesity) tankNode->setObese();
+        else if (flagType->flagEffect == FlagEffect::Tiny) tankNode->setTiny();
+        else if (flagType->flagEffect == FlagEffect::Narrow) tankNode->setNarrow();
+        else if (flagType->flagEffect == FlagEffect::Thief) tankNode->setThief();
         else tankNode->setNormal();
     }
 
     // is this tank fully cloaked?
-    const bool cloaked = (flagType == Flags::Cloaking) && (color[3] == 0.0f);
+    const bool cloaked = (flagType->flagEffect == FlagEffect::Cloaking) && (color[3] == 0.0f);
 
     if (cloaked && !seerView)
     {
@@ -1127,7 +1127,7 @@ void Player::setLandingSpeed(float velocity)
     //
     float k = 0.1f / (2.0f * gravity * gravity);
     k = k * squishiness;
-    if (flagType == Flags::Bouncy)
+    if (flagType->flagEffect == FlagEffect::Bouncy)
         k = k * 4.0f;
     const float newZscale = 1.0f / (1.0f + (k * (velocity * velocity)));
 
@@ -1182,13 +1182,13 @@ float Player::getFlagReload(FlagType::Ptr flag) const
 
     if (flag != nullptr)
     {
-        if (flag == Flags::RapidFire)
+        if (flag->flagEffect == FlagEffect::RapidFire)
             baseReload /= BZDB.eval(StateDatabase::BZDB_RFIREADRATE);
-        else if (flag == Flags::MachineGun)
+        else if (flag->flagEffect == FlagEffect::MachineGun)
             baseReload /= BZDB.eval(StateDatabase::BZDB_MGUNADRATE);
-        else if (flag == Flags::Laser)
+        else if (flag->flagEffect == FlagEffect::Laser)
             baseReload /= BZDB.eval(StateDatabase::BZDB_LASERADRATE);
-        else if (flag == Flags::Thief)
+        else if (flag->flagEffect == FlagEffect::Thief)
             baseReload /= BZDB.eval(StateDatabase::BZDB_THIEFADRATE);
     }
 
@@ -1386,7 +1386,7 @@ bool Player::isDeadReckoningWrong() const
 
     // always send a new packet on reckoned touchdown
     float groundLimit = 0.0f;
-    if (getFlag() == Flags::Burrow)
+    if (getFlag()->flagEffect == FlagEffect::Burrow)
         groundLimit = BZDB.eval(StateDatabase::BZDB_BURROWDEPTH);
     if (predictedPos[2] < groundLimit)
         return true;
@@ -1457,7 +1457,7 @@ void Player::doDeadReckoning()
 
     // if hit ground then update input state (we don't want to fall anymore)
     float groundLimit = 0.0f;
-    if (getFlag() == Flags::Burrow)
+    if (getFlag()->flagEffect == FlagEffect::Burrow)
         groundLimit = BZDB.eval(StateDatabase::BZDB_BURROWDEPTH);
     // the velocity check is for when a Burrow flag is dropped
     if ((predictedPos[2] < groundLimit) && (predictedVel[2] <= 0.0f))
@@ -1490,7 +1490,7 @@ void Player::doDeadReckoning()
             // setup the sound
             if (BZDB.isTrue("remoteSounds"))
             {
-                if ((getFlag() != Flags::Burrow) || (predictedPos[2] > 0.0f))
+                if ((getFlag()->flagEffect != FlagEffect::Burrow) || (predictedPos[2] > 0.0f))
                     playSound(SFX_LAND, state.pos, soundImportance, localSound);
                 else
                 {

--- a/src/bzflag/Player.cxx
+++ b/src/bzflag/Player.cxx
@@ -203,6 +203,15 @@ void Player::addShotToSlot(ShotPath::Ptr shot)
     ShotSlots[slotIndex].reloadTime = ShotSlots[slotIndex].totalReload = getFlagReload(shot->getFiringInfo().flagType);
 }
 
+void  Player::addEmptyShotToSlot(int slotIndex)
+{
+    if (slotIndex > World::getWorld()->getMaxShots())
+        return; // it's not a slot based shot
+
+    ShotSlots[slotIndex].activeShot = nullptr;
+    ShotSlots[slotIndex].reloadTime = ShotSlots[slotIndex].totalReload = getFlagReload(getFlag());
+}
+
 void Player::addShot(const FiringInfo& info)
 {
     const float *f = getForward();
@@ -1192,7 +1201,7 @@ float Player::getFlagReload(FlagType::Ptr flag) const
             baseReload /= BZDB.eval(StateDatabase::BZDB_THIEFADRATE);
     }
 
-    // TODO, use per tank atrtribute factors to modify base value
+    // TODO, use per tank attribute factors to modify base value
 
     return baseReload;
 }

--- a/src/bzflag/Player.h
+++ b/src/bzflag/Player.h
@@ -588,7 +588,7 @@ inline bool     Player::isExploding() const
 
 inline bool     Player::isPhantomZoned() const
 {
-    return (isFlagActive() && (getFlag() == Flags::PhantomZone));
+    return (isFlagActive() && (getFlag()->flagEffect == FlagEffect::PhantomZone));
 }
 
 inline bool     Player::isCrossingWall() const

--- a/src/bzflag/Player.h
+++ b/src/bzflag/Player.h
@@ -89,6 +89,7 @@ public:
     bool            hasFreeShotSlot();
     int             getNextShotSlot();
     virtual void    addShotToSlot(ShotPath::Ptr shot);
+    virtual void    addEmptyShotToSlot(int slotID);
 
     const  ShotSlot::Vec& getShotSlots() const { return ShotSlots; }
 

--- a/src/bzflag/RadarRenderer.cxx
+++ b/src/bzflag/RadarRenderer.cxx
@@ -123,7 +123,7 @@ void RadarRenderer::setTankColor(const Player* player)
         const float dimfactor = 0.4f;
 
         const float *color;
-        if (myTank->getFlag() == Flags::Colorblindness)
+        if (myTank->getFlag()->flagEffect == FlagEffect::Colorblindness)
             color = Team::getRadarColor(RogueTeam);
         else
             color = Team::getRadarColor(player->getTeam());
@@ -136,11 +136,10 @@ void RadarRenderer::setTankColor(const Player* player)
     }
     else
     {
-        glColor3fv(Team::getRadarColor(myTank->getFlag() ==
-                                       Flags::Colorblindness ? RogueTeam : player->getTeam()));
+        glColor3fv(Team::getRadarColor(myTank->getFlag()->flagEffect == FlagEffect ::Colorblindness ? RogueTeam : player->getTeam()));
     }
     // If this tank is hunted flash it on the radar
-    if (player->isHunted() && myTank->getFlag() != Flags::Colorblindness)
+    if (player->isHunted() && myTank->getFlag()->flagEffect != FlagEffect::Colorblindness)
     {
         if (flashTank.isOn())
         {
@@ -427,7 +426,7 @@ void RadarRenderer::render(SceneRenderer& renderer, bool blank, bool observer)
     float radarRange = BZDB.eval("displayRadarRange") * radarLimit;
     float maxRange = radarLimit;
     // when burrowed, limit radar range
-    if (myTank && (myTank->getFlag() == Flags::Burrow) &&
+    if (myTank && (myTank->getFlag()->flagEffect == FlagEffect::Burrow) &&
             (myTank->getPosition()[2] < 0.0f))
         maxRange = radarLimit / 4.0f;
     if (radarRange > maxRange)
@@ -653,8 +652,8 @@ void RadarRenderer::render(SceneRenderer& renderer, bool blank, bool observer)
             if (!player->isAlive() &&
                     (!useTankModels || !observer || !player->isExploding()))
                 continue;
-            if ((player->getFlag() == Flags::Stealth) &&
-                    (myTank->getFlag() != Flags::Seer))
+            if ((player->getFlag()->flagEffect == FlagEffect::Stealth) &&
+                    (myTank->getFlag()->flagEffect != FlagEffect::Seer))
                 continue;
 
             const float* position = player->getPosition();
@@ -673,7 +672,7 @@ void RadarRenderer::render(SceneRenderer& renderer, bool blank, bool observer)
 
         bool coloredShot = BZDB.isTrue("coloredradarshots");
         // draw other tanks' shells
-        bool iSeeAll = myTank && (myTank->getFlag() == Flags::Seer);
+        bool iSeeAll = myTank && (myTank->getFlag()->flagEffect == FlagEffect::Seer);
 
         for (i = 0; i < curMaxPlayers; i++)
         {
@@ -683,12 +682,12 @@ void RadarRenderer::render(SceneRenderer& renderer, bool blank, bool observer)
 
             for (auto shot : player->getShots())
             {
-                if (shot && (shot->getFlag() != Flags::InvisibleBullet || iSeeAll))
+                if (shot && (shot->getFlag()->flagEffect != FlagEffect::InvisibleBullet || iSeeAll))
                 {
                     const float *shotcolor;
                     if (coloredShot)
                     {
-                        if (myTank->getFlag() == Flags::Colorblindness)
+                        if (myTank->getFlag()->flagEffect == FlagEffect::Colorblindness)
                             shotcolor = Team::getRadarColor(RogueTeam);
                         else
                             shotcolor = Team::getRadarColor(player->getTeam());

--- a/src/bzflag/RemotePlayer.cxx
+++ b/src/bzflag/RemotePlayer.cxx
@@ -41,7 +41,7 @@ void            RemotePlayer::addShot(const FiringInfo& info)
 
     // Update tanks position and set dead reckoning for better lag handling
     // shot origin is center of tank for shockwave
-    if (info.flagType == Flags::ShockWave)
+    if (info.flagType->flagEffect == FlagEffect::ShockWave)
     {
         newpos[0] = info.shot.pos[0];
         newpos[1] = info.shot.pos[1];
@@ -51,9 +51,9 @@ void            RemotePlayer::addShot(const FiringInfo& info)
     else
     {
         float front = BZDB.eval(StateDatabase::BZDB_MUZZLEFRONT);
-        if (info.flagType == Flags::Obesity) front *= BZDB.eval(StateDatabase::BZDB_OBESEFACTOR);
-        else if (info.flagType == Flags::Tiny) front *= BZDB.eval(StateDatabase::BZDB_TINYFACTOR);
-        else if (info.flagType == Flags::Thief) front *= BZDB.eval(StateDatabase::BZDB_THIEFTINYFACTOR);
+        if (info.flagType->flagEffect == FlagEffect::Obesity) front *= BZDB.eval(StateDatabase::BZDB_OBESEFACTOR);
+        else if (info.flagType->flagEffect == FlagEffect::Tiny) front *= BZDB.eval(StateDatabase::BZDB_TINYFACTOR);
+        else if (info.flagType->flagEffect == FlagEffect::Thief) front *= BZDB.eval(StateDatabase::BZDB_THIEFTINYFACTOR);
         newpos[0] = info.shot.pos[0] - (front * f[0]);
         newpos[1] = info.shot.pos[1] - (front * f[1]);
         newpos[2] = info.shot.pos[2] - BZDB.eval(StateDatabase::BZDB_MUZZLEHEIGHT);

--- a/src/bzflag/RobotPlayer.cxx
+++ b/src/bzflag/RobotPlayer.cxx
@@ -95,9 +95,9 @@ void RobotPlayer::getProjectedPosition(const Player *targ, float *projpos) const
     double distance = hypotf(deltax,deltay) - BZDB.eval(StateDatabase::BZDB_MUZZLEFRONT) - BZDBCache::tankRadius;
     if (distance <= 0) distance = 0;
     double shotspeed = BZDB.eval(StateDatabase::BZDB_SHOTSPEED)*
-                       (getFlag() == Flags::Laser ? BZDB.eval(StateDatabase::BZDB_LASERADVEL) :
-                        getFlag() == Flags::RapidFire ? BZDB.eval(StateDatabase::BZDB_RFIREADVEL) :
-                        getFlag() == Flags::MachineGun ? BZDB.eval(StateDatabase::BZDB_MGUNADVEL) : 1) +
+                       (getFlag()->flagEffect == FlagEffect::Laser ? BZDB.eval(StateDatabase::BZDB_LASERADVEL) :
+                        getFlag()->flagEffect == FlagEffect::RapidFire ? BZDB.eval(StateDatabase::BZDB_RFIREADVEL) :
+                        getFlag()->flagEffect == FlagEffect::MachineGun ? BZDB.eval(StateDatabase::BZDB_MGUNADVEL) : 1) +
                        hypotf(getVelocity()[0], getVelocity()[1]);
 
     double errdistance = 1.0;
@@ -240,11 +240,11 @@ void            RobotPlayer::doUpdateMotion(float dt)
                 if (shot == nullptr || shot->isExpired())
                     continue;
                 // ignore invisible bullets completely for now (even when visible)
-                if (shot->getFlag() == Flags::InvisibleBullet)
+                if (shot->getFlag()->flagEffect == FlagEffect::InvisibleBullet)
                     continue;
 
                 const float* shotPos = shot->getPosition();
-                if ((fabs(shotPos[2] - position[2]) > BZDBCache::tankHeight) && (shot->getFlag() != Flags::GuidedMissile))
+                if ((fabs(shotPos[2] - position[2]) > BZDBCache::tankHeight) && (shot->getFlag()->flagEffect != FlagEffect::GuidedMissile))
                     continue;
                 const float dist = TargetingUtils::getTargetDistance(position, shotPos);
                 if (dist < 150.0f)

--- a/src/bzflag/ScoreboardRenderer.cxx
+++ b/src/bzflag/ScoreboardRenderer.cxx
@@ -771,10 +771,10 @@ void ScoreboardRenderer::drawPlayerScore(const Player* player,
         // color special flags
         if (BZDBCache::colorful)
         {
-            if ((flagd == Flags::ShockWave)
+            if ((flagd->flagEffect == FlagEffect::ShockWave)
                     ||  (flagd->flagAbbv == "G")
-                    ||  (flagd == Flags::Laser)
-                    ||  (flagd == Flags::GuidedMissile))
+                    ||  (flagd->flagEffect == FlagEffect::Laser)
+                    ||  (flagd->flagEffect == FlagEffect::GuidedMissile))
                 playerInfo += ColorStrings[WhiteColor];
             else if (flagd->flagTeam != NoTeam)
             {

--- a/src/bzflag/SegmentedShotStrategy.cxx
+++ b/src/bzflag/SegmentedShotStrategy.cxx
@@ -234,7 +234,7 @@ float  SegmentedShotStrategy::checkHit(const BaseLocalPlayer* tank, float positi
     for (int i = lastSegment; i <= segment && i < numSegments; i++)
     {
         // can never hit your own first laser segment
-        if (i == 0 && getFlag() == Flags::Laser &&
+        if (i == 0 && getFlag()->flagEffect == FlagEffect::Laser &&
                 getPlayer() == tank->getId())
             continue;
 
@@ -254,7 +254,7 @@ float  SegmentedShotStrategy::checkHit(const BaseLocalPlayer* tank, float positi
 
         // get hit time
         float t;
-        if (tank->getFlag() == Flags::Narrow)
+        if (tank->getFlag()->flagEffect == FlagEffect::Narrow)
         {
             // find closest approach to narrow box around tank.  width of box
             // is shell radius so you can actually hit narrow tank head on.
@@ -820,7 +820,7 @@ LaserStrategy::LaserStrategy(const FiringInfo& _info) :
     const int numSegments = getSegments().size();
     laserNodes = new LaserSceneNode*[numSegments];
     const LocalPlayer* myTank = LocalPlayer::getMyTank();
-    TeamColor tmpTeam = (myTank->getFlag() == Flags::Colorblindness) ? RogueTeam : team;
+    TeamColor tmpTeam = (myTank->getFlag()->flagEffect == FlagEffect::Colorblindness) ? RogueTeam : team;
 
     TextureManager &tm = TextureManager::instance();
     std::string imageName = Team::getImagePrefix(tmpTeam);

--- a/src/bzflag/ShockWaveStrategy.cxx
+++ b/src/bzflag/ShockWaveStrategy.cxx
@@ -78,7 +78,7 @@ void ShockWaveStrategy::update(float dt)
     // team color
     const LocalPlayer* myTank = LocalPlayer::getMyTank();
     TeamColor currentTeam;
-    if ((myTank->getFlag() == Flags::Colorblindness) &&
+    if ((myTank->getFlag()->flagEffect == FlagEffect::Colorblindness) &&
             (getPlayer() != ServerPlayer))
         currentTeam = RogueTeam;
     else

--- a/src/bzflag/ShotPath.cxx
+++ b/src/bzflag/ShotPath.cxx
@@ -44,7 +44,7 @@ FiringInfo::FiringInfo(const BaseLocalPlayer& tank, int _localID)
     // wee bit o hack -- if phantom flag but not phantomized
     // the shot flag is normal -- otherwise FiringInfo will have
     // to be changed to add a real bitwise status variable
-    if (tank.getFlag() == Flags::PhantomZone && !tank.isFlagActive())
+    if (tank.getFlag()->flagEffect == FlagEffect::PhantomZone && !tank.isFlagActive())
         flagType = Flags::Null;
     lifetime = BZDB.eval(StateDatabase::BZDB_RELOADTIME);
 }
@@ -64,23 +64,23 @@ FiringInfo::FiringInfo(const BaseLocalPlayer& tank, int _localID)
          return std::make_shared<NormalShotStrategy>(info);
      else
      {
-         if (info.flagType == Flags::RapidFire)
+         if (info.flagType->flagEffect == FlagEffect::RapidFire)
              return std::make_shared<RapidFireStrategy>(info);
-         else if (info.flagType == Flags::MachineGun)
+         else if (info.flagType->flagEffect == FlagEffect::MachineGun)
              return std::make_shared< MachineGunStrategy>(info);
-         else if (info.flagType == Flags::GuidedMissile)
+         else if (info.flagType->flagEffect == FlagEffect::GuidedMissile)
              return std::make_shared<GuidedMissileStrategy>(info);
-         else if (info.flagType == Flags::Laser)
+         else if (info.flagType->flagEffect == FlagEffect::Laser)
              return std::make_shared<LaserStrategy>(info);
-         else if (info.flagType == Flags::Ricochet)
+         else if (info.flagType->flagEffect == FlagEffect::Ricochet)
              return std::make_shared<RicochetStrategy>(info);
-         else if (info.flagType == Flags::SuperBullet)
+         else if (info.flagType->flagEffect == FlagEffect::SuperBullet)
              return std::make_shared<SuperBulletStrategy>(info);
-         else if (info.flagType == Flags::ShockWave)
+         else if (info.flagType->flagEffect == FlagEffect::ShockWave)
              return std::make_shared<ShockWaveStrategy>(info);
-         else if (info.flagType == Flags::Thief)
+         else if (info.flagType->flagEffect == FlagEffect::Thief)
              return std::make_shared<ThiefStrategy>(info);
-         else if (info.flagType == Flags::PhantomZone)
+         else if (info.flagType->flagEffect == FlagEffect::PhantomZone)
              return std::make_shared<PhantomBulletStrategy>(info);
          else
              assert(0);    // shouldn't happen

--- a/src/bzflag/World.cxx
+++ b/src/bzflag/World.cxx
@@ -878,7 +878,7 @@ void            World::updateFlag(int index, float dt)
         }
         if (flagPlayer != NULL)
         {
-            if (flag.type == Flags::Narrow)
+            if (flag.type->flagEffect == FlagEffect::Narrow)
             {
                 flagNodes[index]->setAngle(flagPlayer->getAngle());
                 flagNodes[index]->setBillboard(false);
@@ -918,7 +918,7 @@ void            World::addFlags(SceneDatabase* scene, bool seerView)
         // Cloaking flag on a tank if we don't have a Seer flag.
         if (flags[i].status == FlagStatus::OnTank)
         {
-            if ((flags[i].type == Flags::Cloaking) && !seerView)
+            if ((flags[i].type->flagEffect == FlagEffect::Cloaking) && !seerView)
                 continue;
             int j;
             for (j = 0; j < curMaxPlayers; j++)

--- a/src/bzflag/clientCommands.cxx
+++ b/src/bzflag/clientCommands.cxx
@@ -353,7 +353,7 @@ static std::string cmdDrop(const std::string&,
         FlagType::Ptr flag = myTank->getFlag();
         if ((flag != Flags::Null) && !myTank->isPaused() &&
                 (flag->endurance != FlagEndurance::Sticky) && !myTank->isPhantomZoned() &&
-                !(flag == Flags::OscillationOverthruster &&
+                !(flag->flagEffect == FlagEffect::OscillationOverthruster &&
                   myTank->getLocation() == LocalPlayer::InBuilding))
         {
             serverLink->sendDropFlag(myTank->getPosition());
@@ -372,7 +372,7 @@ static std::string cmdIdentify(const std::string&,
         return "usage: identify";
     LocalPlayer *myTank = LocalPlayer::getMyTank();
 
-    if (myTank != nullptr && myTank->isAlive() && !myTank->isPaused() && myTank->getFlag() == Flags::GuidedMissile)  // per specification from Blast007, GM locks can only be initizated by people with the GM flag
+    if (myTank != nullptr && myTank->isAlive() && !myTank->isPaused() && myTank->getFlag()->flagEffect == FlagEffect::GuidedMissile)  // per specification from Blast007, GM locks can only be initizated by people with the GM flag
         setTarget();
 
     return std::string();

--- a/src/bzflag/effectsRenderer.cxx
+++ b/src/bzflag/effectsRenderer.cxx
@@ -486,9 +486,9 @@ DeathEffect* EffectsRenderer::addDeathEffect (const float *rgb, const float *pos
 
     // if (reason == GotKilledMsg)
     //   effect = new FadeToHeaven();
-    // else if (reason == GotRunOver || flag == Flags::Steamroller)
+    // else if (reason == GotRunOver || flag->flagEffect == FlagEffect::Steamroller)
     //   effect = new SquishDeathEffect;
-    // else if (flag == Flags::GuidedMissile)
+    // else if (flag->flagEffect == FlagEffect::GuidedMissile)
     //   effect = new SpikesDeathEffect;
     // else
     effect = new RingsDeathEffect;

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -913,7 +913,7 @@ static void     doMotion()
     int keyboardRotation = myTank->getRotation();
     int keyboardSpeed    = myTank->getSpeed();
     /* see if controls are reversed */
-    if (myTank->getFlag() == Flags::ReverseControls)
+    if (myTank->getFlag()->flagEffect == FlagEffect::ReverseControls)
     {
         keyboardRotation = -keyboardRotation;
         keyboardSpeed    = -keyboardSpeed;
@@ -951,7 +951,7 @@ static void     doMotion()
     } // mainWindow->Joystick
 
     /* see if controls are reversed */
-    if (myTank->getFlag() == Flags::ReverseControls)
+    if (myTank->getFlag()->flagEffect == FlagEffect::ReverseControls)
     {
         mx = -mx;
         my = -my;
@@ -1355,8 +1355,8 @@ static void     updateFlag(FlagType::Ptr flag)
     if ((!radar && !myTank) || !World::getWorld())
         return;
 
-    radar->setJammed(flag == Flags::Jamming);
-    hud->setAltitudeTape(flag == Flags::Jumping || World::getWorld()->allowJumping());
+    radar->setJammed(flag->flagEffect == FlagEffect::Jamming);
+    hud->setAltitudeTape(flag->flagEffect == FlagEffect::Jumping || World::getWorld()->allowJumping());
 }
 
 
@@ -1917,7 +1917,7 @@ static void     handleServerMessage(bool human, uint16_t code,
     case MsgNearFlag:
         // MsgNearFlag may arrive up to 1 lag period after dropping ID,
         // so process this only when carrying the ID flag
-        if (myTank && myTank->getFlag() == Flags::Identify)
+        if (myTank && myTank->getFlag()->flagEffect == FlagEffect::Identify)
             handleNearFlag(msg,len);
         break;
 
@@ -2305,7 +2305,7 @@ static void     handleServerMessage(bool human, uint16_t code,
                             || (tank != ROAM.getTargetTank())))
                         || BZDB.isTrue("enableLocalSpawnEffect"))
                 {
-                    if (myTank->getFlag() == Flags::Colorblindness)
+                    if (myTank->getFlag()->flagEffect == FlagEffect::Colorblindness)
                     {
                         static float cbColor[4] = {1,1,1,1};
                         EFFECTS.addSpawnEffect(cbColor, pos);
@@ -2649,17 +2649,17 @@ static void     handleServerMessage(bool human, uint16_t code,
                 playerStr += ColorStrings[WhiteColor];
 
                 // Give more informative kill messages
-                if (flagType == Flags::Laser)
+                if (flagType->flagEffect == FlagEffect::Laser)
                     message += "was fried by " + playerStr + "'s laser";
-                else if (flagType == Flags::GuidedMissile)
+                else if (flagType->flagEffect == FlagEffect::GuidedMissile)
                     message += "was destroyed by " + playerStr + "'s guided missile";
-                else if (flagType == Flags::ShockWave)
+                else if (flagType->flagEffect == FlagEffect::ShockWave)
                     message += "felt the effects of " + playerStr + "'s shockwave";
-                else if (flagType == Flags::InvisibleBullet)
+                else if (flagType->flagEffect == FlagEffect::InvisibleBullet)
                     message += "didn't see " + playerStr + "'s bullet";
-                else if (flagType == Flags::MachineGun)
+                else if (flagType->flagEffect == FlagEffect::MachineGun)
                     message += "was turned into swiss cheese by " + playerStr + "'s machine gun";
-                else if (flagType == Flags::SuperBullet)
+                else if (flagType->flagEffect == FlagEffect::SuperBullet)
                     message += "got skewered by " + playerStr + "'s super bullet";
                 else
                     message += "killed by " + playerStr;
@@ -2966,13 +2966,13 @@ static void     handleServerMessage(bool human, uint16_t code,
                 const float* pos = firingInfo.shot.pos;
                 const bool importance = false;
                 const bool localSound = isViewTank(shooter);
-                if (firingInfo.flagType == Flags::ShockWave)
+                if (firingInfo.flagType->flagEffect == FlagEffect::ShockWave)
                     playSound(SFX_SHOCK, pos, importance, localSound);
-                else if (firingInfo.flagType == Flags::Laser)
+                else if (firingInfo.flagType->flagEffect == FlagEffect::Laser)
                     playSound(SFX_LASER, pos, importance, localSound);
-                else if (firingInfo.flagType == Flags::GuidedMissile)
+                else if (firingInfo.flagType->flagEffect == FlagEffect::GuidedMissile)
                     playSound(SFX_MISSILE, pos, importance, localSound);
-                else if (firingInfo.flagType == Flags::Thief)
+                else if (firingInfo.flagType->flagEffect == FlagEffect::Thief)
                     playSound(SFX_THIEF, pos, importance, localSound);
                 else
                     playSound(SFX_FIRE, pos, importance, localSound);
@@ -3822,13 +3822,13 @@ void handleFlagDropped(Player* tank)
     if (tank == myTank)
     {
         // make sure the player must reload after theft
-        if (tank->getFlag() == Flags::Thief)
+        if (tank->getFlag()->flagEffect == FlagEffect::Thief)
             myTank->forceReload(BZDB.eval(StateDatabase::BZDB_THIEFDROPTIME));
         //drop lock if i had GM
-        if (myTank->getFlag() == Flags::GuidedMissile)
+        if (myTank->getFlag()->flagEffect == FlagEffect::GuidedMissile)
             myTank->setTarget(NULL);
         // if they were zoned, reset their status
-        if (myTank->getFlag() == Flags::PhantomZone)
+        if (myTank->getFlag()->flagEffect == FlagEffect::PhantomZone)
             myTank->setStatus(short(PlayerState::Alive));
 
         // update display and play sound effects
@@ -3938,7 +3938,7 @@ static bool     gotBlowedUp(BaseLocalPlayer* tank,
     // message when it gets back to us -- do this by ignoring killed
     // message if we're already dead.
     // don't die if we had the shield flag and we've been shot.
-    if (reason != GotShot || flag != Flags::Shield)
+    if (reason != GotShot || flag->flagEffect != FlagEffect::Shield)
     {
         // blow me up
 
@@ -4055,7 +4055,7 @@ static bool     gotBlowedUp(BaseLocalPlayer* tank,
     // hit me again if I had the shield flag.  this is important for the
     // shots that aren't stopped by a hit and so may stick around to hit
     // me on the next update, making the shield useless.
-    return (reason == GotShot && flag == Flags::Shield && shotId != -1);
+    return (reason == GotShot && flag->flagEffect == FlagEffect::Shield && shotId != -1);
 }
 
 static void     checkEnvironment()
@@ -4087,7 +4087,7 @@ static void     checkEnvironment()
             return;
 
         flagd = target->getFlag();
-        if ((flagd == Flags::Narrow) || (flagd == Flags::Tiny))
+        if ((flagd->flagEffect == FlagEffect::Narrow) || (flagd->flagEffect == FlagEffect::Tiny))
             // Don't bother trying to figure this out with a narrow or tiny flag yet.
             return;
 
@@ -4193,7 +4193,7 @@ static void     checkEnvironment()
         FlagType::Ptr killerFlag = hit->getFlag();
         bool stopShot;
 
-        if (killerFlag == Flags::Thief)
+        if (killerFlag->flagEffect == FlagEffect::Thief)
         {
             if (myTank->getFlag() != Flags::Null)
                 serverLink->sendStealFlag(myTank->getId(), hit->getPlayer());
@@ -4225,7 +4225,7 @@ static void     checkEnvironment()
         for (i = 0; i < curMaxPlayers; i++)
         {
             if (remotePlayers[i] && !remotePlayers[i]->isPaused() &&
-                    ((remotePlayers[i]->getFlag() == Flags::Steamroller) ||
+                    ((remotePlayers[i]->getFlag()->flagEffect == FlagEffect::Steamroller) ||
                      ((myPos[2] < 0.0f) && remotePlayers[i]->isAlive() &&
                       !remotePlayers[i]->isPhantomZoned())))
             {
@@ -4258,12 +4258,12 @@ bool inLookRange(float angle, float distance, float bestDistance, RemotePlayer *
     if (distance > BZDB.eval(StateDatabase::BZDB_TARGETINGDISTANCE) || distance > bestDistance)
         return false;
 
-    if (myTank->getFlag() == Flags::Blindness)
+    if (myTank->getFlag()->flagEffect == FlagEffect::Blindness)
         return false;
 
-    if (player->getFlag() == Flags::Stealth ||
-            player->getFlag() == Flags::Cloaking)
-        return myTank->getFlag() == Flags::Seer;
+    if (player->getFlag()->flagEffect == FlagEffect::Stealth ||
+            player->getFlag()->flagEffect == FlagEffect::Cloaking)
+        return myTank->getFlag()->flagEffect == FlagEffect::Seer;
 
     return true;
 }
@@ -4274,7 +4274,7 @@ static bool isKillable(const Player *target)
         return false;
     if (target->getTeam() == RogueTeam)
         return true;
-    if (myTank->getFlag() == Flags::Colorblindness)
+    if (myTank->getFlag()->flagEffect == FlagEffect::Colorblindness)
         return true;
     if (! World::getWorld()->allowTeamKills() || ! World::getWorld()->allowTeams())
         return true;
@@ -4294,7 +4294,7 @@ static bool isFriendly(const Player *target)
 
     if (target->getTeam() == RogueTeam)
         return false;
-    if (myTank->getFlag() == Flags::Colorblindness)
+    if (myTank->getFlag()->flagEffect == FlagEffect::Colorblindness)
         return false;
 
     return target->getTeam() == myTank->getTeam();
@@ -4371,7 +4371,7 @@ void setLookAtMarker(void)
     if (!bestTarget)
         return;
 
-    if (myTank->getFlag() == Flags::Blindness)
+    if (myTank->getFlag()->flagEffect == FlagEffect::Blindness)
         return;
 
     std::string label = bestTarget->getCallSign();
@@ -4385,11 +4385,11 @@ void setLookAtMarker(void)
 
     TeamColor markercolor = bestTarget->getTeam();
 
-    if (bestTarget->getFlag() == Flags::Masquerade &&
-            myTank->getFlag() != Flags::Seer)
+    if (bestTarget->getFlag()->flagEffect == FlagEffect::Masquerade &&
+            myTank->getFlag()->flagEffect != FlagEffect::Seer)
         markercolor = myTank->getTeam();
 
-    if (myTank->getFlag() == Flags::Colorblindness)
+    if (myTank->getFlag()->flagEffect == FlagEffect::Colorblindness)
         markercolor = RogueTeam;
 
     hud->AddEnhancedNamedMarker(Float3ToVec3(bestTarget->getPosition()),
@@ -4397,11 +4397,11 @@ void setLookAtMarker(void)
                                 label, isFriendly(bestTarget), 2.0f);
 }
 
-static inline bool tankHasShotType(const Player* tank, const FlagType::Ptr ft)
+static inline bool tankHasShotType(const Player* tank, FlagEffect ft)
 {
     for (auto sp : tank->getShots())
     {
-        if ((sp != nullptr) && (sp->getFlag() == ft))
+        if ((sp != nullptr) && (sp->getFlag()->flagEffect == ft))
             return true;
     }
     return false;
@@ -4439,9 +4439,9 @@ void setTarget()
 
         // see if it's inside lock-on angle (if we're trying to lock-on)
         if (a < BZDB.eval(StateDatabase::BZDB_LOCKONANGLE) &&   // about 8.5 degrees
-                ((myTank->getFlag() == Flags::GuidedMissile) ||     // am i locking on?
-                 tankHasShotType(myTank, Flags::GuidedMissile)) &&
-                remotePlayers[i]->getFlag() != Flags::Stealth &&        // can't lock on stealth
+                ((myTank->getFlag()->flagEffect == FlagEffect::GuidedMissile) ||     // am i locking on?
+                 tankHasShotType(myTank, FlagEffect::GuidedMissile)) &&
+                remotePlayers[i]->getFlag()->flagEffect != FlagEffect::Stealth &&        // can't lock on stealth
                 !remotePlayers[i]->isPaused() &&                // can't lock on paused
                 !remotePlayers[i]->isNotResponding() &&         // can't lock on not responding
                 d < bestDistance)                   // is it better?
@@ -4451,7 +4451,7 @@ void setTarget()
             lockedOn = true;
         }
         else if (a < BZDB.eval(StateDatabase::BZDB_TARGETINGANGLE) &&               // about 17 degrees
-                 ((remotePlayers[i]->getFlag() != Flags::Stealth) || (myTank->getFlag() == Flags::Seer))
+                 ((remotePlayers[i]->getFlag()->flagEffect != FlagEffect::Stealth) || (myTank->getFlag()->flagEffect == FlagEffect::Seer))
                  && // can't "see" stealth unless have seer
                  d < bestDistance && !lockedOn)         // is it better?
         {
@@ -4496,7 +4496,7 @@ void setTarget()
         if (sentForbidIdentify < 10)
             sentForbidIdentify++;
     }
-    else if (myTank->getFlag() == Flags::Colorblindness)
+    else if (myTank->getFlag()->flagEffect == FlagEffect::Colorblindness)
     {
         std::string msg("Looking at a tank");
         hud->setAlert(1, msg.c_str(), 2.0f, 0);
@@ -4557,8 +4557,8 @@ static void setHuntTarget()
 
         // see if it's inside lock-on angle (if we're trying to lock-on)
         if (a < BZDB.eval(StateDatabase::BZDB_LOCKONANGLE) &&                   // about 8.5 degrees
-                myTank->getFlag() == Flags::GuidedMissile &&    // am i locking on?
-                remotePlayers[i]->getFlag() != Flags::Stealth &&    // can't lock on stealth
+                myTank->getFlag()->flagEffect == FlagEffect::GuidedMissile &&    // am i locking on?
+                remotePlayers[i]->getFlag()->flagEffect != FlagEffect::Stealth &&    // can't lock on stealth
                 !remotePlayers[i]->isPaused() &&            // can't lock on paused
                 !remotePlayers[i]->isNotResponding() &&     // can't lock on not responding
                 d < bestDistance)               // is it better?
@@ -4568,7 +4568,7 @@ static void setHuntTarget()
             lockedOn = true;
         }
         else if (a < BZDB.eval(StateDatabase::BZDB_TARGETINGANGLE) &&               // about 17 degrees
-                 ((remotePlayers[i]->getFlag() != Flags::Stealth) || (myTank->getFlag() == Flags::Seer))
+                 ((remotePlayers[i]->getFlag()->flagEffect != FlagEffect::Stealth) || (myTank->getFlag()->flagEffect == FlagEffect::Seer))
                  && // can't "see" stealth unless have seer
                  d < bestDistance && !lockedOn)         // is it better?
         {
@@ -4579,9 +4579,9 @@ static void setHuntTarget()
     if (!bestTarget) return;
 
 
-    if (bestTarget->isHunted() && myTank->getFlag() != Flags::Blindness &&
-            myTank->getFlag() != Flags::Colorblindness &&
-            bestTarget->getFlag() != Flags::Stealth)
+    if (bestTarget->isHunted() && myTank->getFlag()->flagEffect != FlagEffect::Blindness &&
+            myTank->getFlag()->flagEffect != FlagEffect::Colorblindness &&
+            bestTarget->getFlag()->flagEffect != FlagEffect::Stealth)
     {
         if (myTank->getTarget() == NULL)   // Don't interfere with GM lock display
         {
@@ -4747,10 +4747,10 @@ static void     setRobotTarget(RobotPlayer* robot)
                 continue;
 
             if (World::getWorld()->allowTeamFlags() &&
-                    ((robot->getTeam() == RedTeam && remotePlayers[j]->getFlag() == Flags::RedTeam) ||
-                     (robot->getTeam() == GreenTeam && remotePlayers[j]->getFlag() == Flags::GreenTeam) ||
-                     (robot->getTeam() == BlueTeam && remotePlayers[j]->getFlag() == Flags::BlueTeam) ||
-                     (robot->getTeam() == PurpleTeam && remotePlayers[j]->getFlag() == Flags::PurpleTeam)))
+                    ((robot->getTeam() == RedTeam && remotePlayers[j]->getFlag()->flagTeam == RedTeam) ||
+                     (robot->getTeam() == GreenTeam && remotePlayers[j]->getFlag()->flagTeam == GreenTeam) ||
+                     (robot->getTeam() == BlueTeam && remotePlayers[j]->getFlag()->flagTeam == BlueTeam) ||
+                     (robot->getTeam() == PurpleTeam && remotePlayers[j]->getFlag()->flagTeam == PurpleTeam)))
             {
                 bestTarget = remotePlayers[j];
                 break;
@@ -4846,7 +4846,7 @@ static void     checkEnvironment(RobotPlayer* tank)
         FlagType::Ptr killerFlag = hit->getFlag();
         bool stopShot;
 
-        if (killerFlag == Flags::Thief)
+        if (killerFlag->flagEffect == FlagEffect::Thief)
         {
             if (tank->getFlag() != Flags::Null)
                 serverLink->sendStealFlag(tank->getId(), hit->getPlayer());
@@ -4877,8 +4877,8 @@ static void     checkEnvironment(RobotPlayer* tank)
         bool dead = false;
         const float* myPos = tank->getPosition();
         const float myRadius = tank->getRadius();
-        if (((myTank->getFlag() == Flags::Steamroller) ||
-                ((tank->getFlag() == Flags::Burrow) && myTank->isAlive() &&
+        if (((myTank->getFlag()->flagEffect == FlagEffect::Steamroller) ||
+                ((tank->getFlag()->flagEffect == FlagEffect::Burrow) && myTank->isAlive() &&
                  !myTank->isPhantomZoned()))
                 && !myTank->isPaused())
         {
@@ -4900,8 +4900,8 @@ static void     checkEnvironment(RobotPlayer* tank)
         for (i = 0; !dead && i < curMaxPlayers; i++)
         {
             if (remotePlayers[i] && !remotePlayers[i]->isPaused() &&
-                    ((remotePlayers[i]->getFlag() == Flags::Steamroller) ||
-                     ((tank->getFlag() == Flags::Burrow) && remotePlayers[i]->isAlive() &&
+                    ((remotePlayers[i]->getFlag()->flagEffect == FlagEffect::Steamroller) ||
+                     ((tank->getFlag()->flagEffect == FlagEffect::Burrow) && remotePlayers[i]->isAlive() &&
                       !remotePlayers[i]->isPhantomZoned())))
             {
                 const float* pos = remotePlayers[i]->getPosition();
@@ -6003,7 +6003,7 @@ void drawFrame(const float dt)
             myTankDir = myTank->getForward();
             muzzleHeight = myTank->getMuzzleHeight();
 
-            if (myTank->getFlag() == Flags::WideAngle)
+            if (myTank->getFlag()->flagEffect == FlagEffect::WideAngle)
                 fov = 120.0f;
             else
                 fov = BZDB.eval("displayFOV");
@@ -6158,10 +6158,10 @@ void drawFrame(const float dt)
         {
 
             int i;
-            const bool seerView = (myTank->getFlag() == Flags::Seer);
+            const bool seerView = (myTank->getFlag()->flagEffect == FlagEffect::Seer);
             const bool showTreads = BZDB.isTrue("showTreads");
 
-            const bool colorblind = (myTank->getFlag() == Flags::Colorblindness);
+            const bool colorblind = (myTank->getFlag()->flagEffect == FlagEffect::Colorblindness);
             TeamColor effectiveTeam = colorblind ? RogueTeam : myTank->getTeam();
 
             // add my tank if required
@@ -6196,8 +6196,8 @@ void drawFrame(const float dt)
                     effectiveTeam = RogueTeam;
                     if (!colorblind)
                     {
-                        if ((remotePlayers[i]->getFlag() == Flags::Masquerade)
-                                && (myTank->getFlag() != Flags::Seer)
+                        if ((remotePlayers[i]->getFlag()->flagEffect == FlagEffect::Masquerade)
+                                && (myTank->getFlag()->flagEffect != FlagEffect::Seer)
                                 && (myTank->getTeam() != ObserverTeam))
                             effectiveTeam = myTank->getTeam();
                         else
@@ -6234,7 +6234,7 @@ void drawFrame(const float dt)
 
         // turn blanking and inversion on/off as appropriate
         sceneRenderer->setBlank(myTank && (myTank->isPaused() ||
-                                           myTank->getFlag() == Flags::Blindness));
+                                           myTank->getFlag()->flagEffect == FlagEffect::Blindness));
         sceneRenderer->setInvert(myTank && myTank->isPhantomZoned());
 
         // turn on scene dimming when showing menu, when we're dead
@@ -7362,15 +7362,15 @@ static void     playingLoop()
                     setHuntTarget(); //spot hunt target
                 }
                 if (myTank->getTeam() != ObserverTeam &&
-                        ((fireButton && myTank->getFlag() == Flags::MachineGun) ||
-                         (myTank->getFlag() == Flags::TriggerHappy)))
+                        ((fireButton && myTank->getFlag()->flagEffect == FlagEffect::MachineGun) ||
+                         (myTank->getFlag()->flagEffect == FlagEffect::TriggerHappy)))
                     myTank->fireShot();
 
                 setLookAtMarker();
 
                 // see if we have a target, if so lock on to the bastage
                 const Player* targetdPlayer = myTank->getTarget();
-                if (targetdPlayer && targetdPlayer->isAlive() && targetdPlayer->getFlag() != Flags::Stealth)
+                if (targetdPlayer && targetdPlayer->isAlive() && targetdPlayer->getFlag()->flagEffect != FlagEffect::Stealth)
                 {
                     hud->AddLockOnMarker(Float3ToVec3(myTank->getTarget()->getPosition()),
                                          myTank->getTarget()->getCallSign(),

--- a/src/bzfs/FlagInfo.cxx
+++ b/src/bzfs/FlagInfo.cxx
@@ -131,7 +131,7 @@ void FlagInfo::addFlag()
         flag.endurance = FlagEndurance::Unstable;
 
     // how times will it stick around
-    if ((flag.endurance == FlagEndurance::Sticky) || (flag.type == Flags::Thief))
+    if ((flag.endurance == FlagEndurance::Sticky) || (flag.type->flagEffect == FlagEffect::Thief))
         grabs = 1;
     else
         grabs = BZDB.evalInt(StateDatabase::BZDB_MAXFLAGGRABS);
@@ -171,7 +171,7 @@ void FlagInfo::dropFlag(float pos[3], float landingPos[3], bool vanish)
     // altitudes and desired height above start altitude
     const float gravity   = BZDBCache::gravity;
     const float flagAltitude   = BZDB.eval(StateDatabase::BZDB_FLAGALTITUDE);
-    const float thrownAltitude = (flag.type == Flags::Shield) ?
+    const float thrownAltitude = (flag.type->flagEffect == FlagEffect::Shield) ?
                                  BZDB.eval(StateDatabase::BZDB_SHIELDFLIGHT) * flagAltitude : flagAltitude;
     const float maxAltitude    = pos[2] + thrownAltitude;
     const float upTime     = sqrtf(-2.0f * thrownAltitude / gravity);

--- a/src/bzfs/GameKeeper.cxx
+++ b/src/bzfs/GameKeeper.cxx
@@ -407,17 +407,17 @@ void GameKeeper::Player::setMaxShots(unsigned int _maxShots)
 float GetShotLifetime(FlagType::Ptr flagType)
 {
     float lifeTime(BZDB.eval(StateDatabase::BZDB_RELOADTIME));
-    if (flagType == Flags::RapidFire)
+    if (flagType->flagEffect == FlagEffect::RapidFire)
         lifeTime *= BZDB.eval(StateDatabase::BZDB_RFIREADLIFE);
-    else if (flagType == Flags::MachineGun)
+    else if (flagType->flagEffect == FlagEffect::MachineGun)
         lifeTime *= BZDB.eval(StateDatabase::BZDB_MGUNADLIFE);
-    else if (flagType == Flags::GuidedMissile)
+    else if (flagType->flagEffect == FlagEffect::GuidedMissile)
         lifeTime *= BZDB.eval(StateDatabase::BZDB_GMADLIFE) + .01f;
-    else if (flagType == Flags::Laser)
+    else if (flagType->flagEffect == FlagEffect::Laser)
         lifeTime *= BZDB.eval(StateDatabase::BZDB_LASERADLIFE);
-    else if (flagType == Flags::ShockWave)
+    else if (flagType->flagEffect == FlagEffect::ShockWave)
         lifeTime *= BZDB.eval(StateDatabase::BZDB_SHOCKADLIFE);
-    else if (flagType == Flags::Thief)
+    else if (flagType->flagEffect == FlagEffect::Thief)
         lifeTime *= BZDB.eval(StateDatabase::BZDB_THIEFADLIFE);
 
     return lifeTime;

--- a/src/bzfs/ServerSidePlayer.cxx
+++ b/src/bzfs/ServerSidePlayer.cxx
@@ -361,11 +361,11 @@ float computeMaxLinVelocity(FlagType::Ptr flag, float z)
 
     if (flag)
     {
-        if (flag == Flags::Velocity)
+        if (flag->flagEffect == FlagEffect::Velocity)
             return speed * BZDB.eval(StateDatabase::BZDB_VELOCITYAD);
-        else if (flag == Flags::Thief)
+        else if (flag->flagEffect == FlagEffect::Thief)
             return speed * BZDB.eval(StateDatabase::BZDB_THIEFVELAD);
-        else if (flag == Flags::Burrow && z < 0.0f)
+        else if (flag->flagEffect == FlagEffect::Burrow && z < 0.0f)
             return speed * BZDB.eval(StateDatabase::BZDB_BURROWSPEEDAD);
     }
 
@@ -379,9 +379,9 @@ float computeMaxAngleVelocity(FlagType::Ptr flag, float z)
 
     if (flag)
     {
-        if (flag == Flags::QuickTurn)
+        if (flag->flagEffect == FlagEffect::QuickTurn)
             return angvel * BZDB.eval(StateDatabase::BZDB_ANGULARAD);
-        else if (flag == Flags::QuickTurn && z < 0.0f)
+        else if (flag->flagEffect == FlagEffect::QuickTurn && z < 0.0f)
             return angvel * BZDB.eval(StateDatabase::BZDB_BURROWANGULARAD);
     }
 

--- a/src/bzfs/ShotManager.cxx
+++ b/src/bzfs/ShotManager.cxx
@@ -32,7 +32,7 @@ namespace Shots
 
     Manager::Manager()
     {
-        Factories[std::string("")] = std::make_shared<ProjectileShot::Factory>();
+        Factories[FlagEffect::Normal] = std::make_shared<ProjectileShot::Factory>();
         LastGUID = INVALID_SHOT_GUID;
     }
 
@@ -47,34 +47,30 @@ namespace Shots
 
     void Manager::Init()
     {
-        Factories[Flags::GuidedMissile->flagAbbv] = std::make_shared<GuidedMissileShot::Factory>();
-        Factories[Flags::SuperBullet->flagAbbv] = std::make_shared< SuperBulletShot::Factory>();
-        Factories[Flags::ShockWave->flagAbbv] = std::make_shared<ShockwaveShot::Factory>();
-        Factories[Flags::Ricochet->flagAbbv] = std::make_shared<RicoShot::Factory>();
-        Factories[Flags::RapidFire->flagAbbv] = std::make_shared<RapidFireShot::Factory>();
-        Factories[Flags::MachineGun->flagAbbv] = std::make_shared<MachineGunShot::Factory>();
-        Factories[Flags::Laser->flagAbbv] = std::make_shared<LaserShot::Factory>();
-        Factories[Flags::Thief->flagAbbv] = std::make_shared<ThiefShot::Factory>();
-        Factories[Flags::PhantomZone->flagAbbv] = std::make_shared<PhantomShot::Factory>();
+        Factories[FlagEffect::GuidedMissile] = std::make_shared<GuidedMissileShot::Factory>();
+        Factories[FlagEffect::SuperBullet] = std::make_shared< SuperBulletShot::Factory>();
+        Factories[FlagEffect::ShockWave] = std::make_shared<ShockwaveShot::Factory>();
+        Factories[FlagEffect::Ricochet] = std::make_shared<RicoShot::Factory>();
+        Factories[FlagEffect::RapidFire] = std::make_shared<RapidFireShot::Factory>();
+        Factories[FlagEffect::MachineGun] = std::make_shared<MachineGunShot::Factory>();
+        Factories[FlagEffect::Laser] = std::make_shared<LaserShot::Factory>();
+        Factories[FlagEffect::Thief] = std::make_shared<ThiefShot::Factory>();
+        Factories[FlagEffect::PhantomZone] = std::make_shared<PhantomShot::Factory>();
     }
 
-    void Manager::SetShotFactory(const char* flagCode, std::shared_ptr<ShotFactory> factory)
+    void Manager::SetShotFactory(FlagEffect effect, std::shared_ptr<ShotFactory> factory)
     {
-        std::string code;
-        if (flagCode)
-            code = flagCode;
-
-        Factories[code] = factory;
+        Factories[effect] = factory;
     }
 
     uint16_t Manager::AddShot(const FiringInfo &info, PlayerId UNUSED(shooter))
     {
         ShotFactory::Ptr factory = nullptr;
-        if (Factories.find(info.flagType->flagAbbv) != Factories.end())
-            factory = Factories[info.flagType->flagAbbv];
+        if (Factories.find(info.flagType->flagEffect) != Factories.end())
+            factory = Factories[info.flagType->flagEffect];
 
         if (factory == nullptr)
-            factory = Factories[std::string("")];
+            factory = Factories[FlagEffect::Normal];
 
         Shot::Ptr shot = factory->GetShot(NewGUID(), info);
 

--- a/src/bzfs/ShotManager.h
+++ b/src/bzfs/ShotManager.h
@@ -165,7 +165,7 @@ namespace Shots
         virtual  Shot::Ptr GetShot(uint16_t /*guid*/, const FiringInfo &/*info*/) = 0;
 
         typedef std::shared_ptr <ShotFactory> Ptr;
-        typedef std::map<std::string, Ptr > Map;
+        typedef std::map<FlagEffect, Ptr > Map;
     };
 
 #define INVALID_SHOT_GUID 0
@@ -179,7 +179,7 @@ namespace Shots
 
         void Init();
 
-        void SetShotFactory(const char* flagCode, std::shared_ptr<ShotFactory> factory);
+        void SetShotFactory(FlagEffect effect, std::shared_ptr<ShotFactory> factory);
 
         uint16_t AddShot(const FiringInfo &info, PlayerId shooter);
         void RemoveShot(uint16_t shotID);

--- a/src/bzfs/SpawnPolicy.cxx
+++ b/src/bzfs/SpawnPolicy.cxx
@@ -227,21 +227,21 @@ bool SpawnPolicy::isImminentlyDangerous() const
                 const FlagInfo *finfo = FlagInfo::get(playerData->player.getFlag());
                 const FlagType::Ptr ftype = finfo->flag.type;
                 // FIXME: any more?
-                if (ftype == Flags::Laser)    // don't spawn in the line of sight of an L
+                if (ftype->flagEffect == FlagEffect::Laser)    // don't spawn in the line of sight of an L
                 {
                     if (isFacing(enemyPos, enemyAngle, twentyDegrees))   // he's looking within 20 degrees of spawn point
                     {
                         return true;    // eek, don't spawn here
                     }
                 }
-                else if (ftype == Flags::ShockWave)      // don't spawn next to a SW
+                else if (ftype->flagEffect == FlagEffect::ShockWave)      // don't spawn next to a SW
                 {
                     if (distanceFrom(enemyPos) < safeSWRadius)   // too close to SW
                     {
                         return true;    // eek, don't spawn here
                     }
                 }
-                else if (ftype == Flags::Steamroller || ftype == Flags::Burrow)     // don't spawn if you'll squish or be squished
+                else if (ftype->flagEffect == FlagEffect::Steamroller || ftype->flagEffect == FlagEffect::Burrow)     // don't spawn if you'll squish or be squished
                 {
                     if (distanceFrom(enemyPos) < safeSRRadius)   // too close to SR or BU
                     {

--- a/src/bzfs/bzfs.cxx
+++ b/src/bzfs/bzfs.cxx
@@ -4364,15 +4364,12 @@ static void shotFired(int playerIndex, void *buf, int len)
     }
 
 
-    // add the shot to the global list to get it's GUID
-    int guid = ShotManager.AddShot(firingInfo, playerData->getIndex());
-    firingInfo.shot.id = (uint16_t)guid;
-
-    // repack for ID
-    void *bufStart = getDirectMessageBuffer();
-    firingInfo.pack(bufStart);
-    buf = bufStart;
-
+    if (firingInfo.flagType->flagEffect != FlagEffect::NoShot)
+    {
+        // add the shot to the global list to get it's GUID
+        int guid = ShotManager.AddShot(firingInfo, playerData->getIndex());
+        firingInfo.shot.id = (uint16_t)guid;
+    }
 
     // if shooter has a flag
 
@@ -4410,7 +4407,14 @@ static void shotFired(int playerIndex, void *buf, int len)
     if (firingInfo.flagType->flagEffect == FlagEffect::GuidedMissile)
         playerData->player.endShotCredit--;
 
-    broadcastMessage(MsgShotBegin, len, buf);
+    if (firingInfo.flagType->flagEffect != FlagEffect::NoShot)
+    {
+        // repack for ID
+        void *bufStart = getDirectMessageBuffer();
+        firingInfo.pack(bufStart);
+        buf = bufStart;
+        broadcastMessage(MsgShotBegin, len, buf);
+    }
 }
 
 static void shotEnded(const PlayerId& id, uint16_t shotid, uint16_t reason)

--- a/src/bzfs/bzfs.cxx
+++ b/src/bzfs/bzfs.cxx
@@ -3725,7 +3725,7 @@ static void searchFlag(GameKeeper::Player &playerData)
         return;
 
     FlagInfo &playerFlag = *FlagInfo::get(flagId);
-    if (playerFlag.flag.type != Flags::Identify)
+    if (playerFlag.flag.type->flagEffect != FlagEffect::Identify)
         return;
 
     float radius = BZDB.eval(StateDatabase::BZDB_IDENTIFYRANGE);
@@ -3981,7 +3981,7 @@ void dropPlayerFlag(GameKeeper::Player &playerData, const float dropPos[3])
         return;
 
     FlagInfo &flag = *FlagInfo::get(flagIndex);
-    if (flag.flag.type == Flags::Shield)
+    if (flag.flag.type->flagEffect == FlagEffect::Shield)
     {
         playerData.player.endShotCredit -= playerData.player.endShotShieldCredit;
         playerData.player.endShotShieldCredit = 0;
@@ -4160,7 +4160,7 @@ static void shotUpdate(int playerIndex, void *buf, int len)
 
     bool canUpdate = false;
     if (flag != nullptr)
-        canUpdate = flag->flag.type == Flags::GuidedMissile;
+        canUpdate = flag->flag.type->flagEffect == FlagEffect::GuidedMissile;
 
     if (!shooter.isAlive() || shooter.isObserver() || !canUpdate)
         return;
@@ -4243,7 +4243,7 @@ static void shotFired(int playerIndex, void *buf, int len)
         }
 
         // probably a cheater using wrong shots.. exception for thief since they steal someone elses
-        if (firingInfo.flagType != Flags::Thief && checkShotMismatch)
+        if (firingInfo.flagType->flagEffect != FlagEffect::Thief && checkShotMismatch)
         {
             // bye bye supposed cheater
             logDebugMessage(1,"Kicking Player %s [%d] Player using wrong shots\n", shooter.getCallSign(), playerIndex);
@@ -4272,18 +4272,18 @@ static void shotFired(int playerIndex, void *buf, int len)
         tankSpeed *= BZDB.eval(StateDatabase::BZDB_HANDICAPVELAD);
         shotSpeed *= BZDB.eval(StateDatabase::BZDB_HANDICAPSHOTAD);
     }
-    if (firingInfo.flagType == Flags::ShockWave)
+    if (firingInfo.flagType->flagEffect == FlagEffect::ShockWave)
     {
         shotSpeed = 0.0f;
         tankSpeed = 0.0f;
     }
-    else if (firingInfo.flagType == Flags::Velocity)
+    else if (firingInfo.flagType->flagEffect == FlagEffect::Velocity)
         tankSpeed *= tankSpeedMult;
-    else if (firingInfo.flagType == Flags::Thief)
+    else if (firingInfo.flagType->flagEffect == FlagEffect::Thief)
         tankSpeed *= BZDB.eval(StateDatabase::BZDB_THIEFVELAD);
-    else if ((firingInfo.flagType == Flags::Burrow)  && (firingInfo.shot.pos[2] < BZDB.eval(StateDatabase::BZDB_MUZZLEHEIGHT)))
+    else if ((firingInfo.flagType->flagEffect == FlagEffect::Burrow)  && (firingInfo.shot.pos[2] < BZDB.eval(StateDatabase::BZDB_MUZZLEHEIGHT)))
         tankSpeed *= BZDB.eval(StateDatabase::BZDB_BURROWSPEEDAD);
-    else if (firingInfo.flagType == Flags::Agility)
+    else if (firingInfo.flagType->flagEffect == FlagEffect::Agility)
         tankSpeed *= BZDB.eval(StateDatabase::BZDB_AGILITYADVEL);
     else
     {
@@ -4315,7 +4315,7 @@ static void shotFired(int playerIndex, void *buf, int len)
         // verify position
         float muzzleFront = BZDB.eval(StateDatabase::BZDB_MUZZLEFRONT);
         float muzzleHeight = BZDB.eval(StateDatabase::BZDB_MUZZLEHEIGHT);
-        if (firingInfo.flagType == Flags::Obesity)
+        if (firingInfo.flagType->flagEffect == FlagEffect::Obesity)
             muzzleFront *= BZDB.eval(StateDatabase::BZDB_OBESEFACTOR);
         const PlayerState &last = playerData->lastState;
         float dx = last.pos[0] - shot.pos[0];
@@ -4407,7 +4407,7 @@ static void shotFired(int playerIndex, void *buf, int len)
         } // end is limit
     } // end of player has flag
 
-    if (firingInfo.flagType == Flags::GuidedMissile)
+    if (firingInfo.flagType->flagEffect == FlagEffect::GuidedMissile)
         playerData->player.endShotCredit--;
 
     broadcastMessage(MsgShotBegin, len, buf);
@@ -5079,7 +5079,7 @@ static void handleCommand(int t, void *rawbuf, bool udp)
         if (pFlag >= 0)
         {
             FlagInfo &flag = *FlagInfo::get(pFlag);
-            if (flag.flag.type == Flags::Shield)
+            if (flag.flag.type->flagEffect == FlagEffect::Shield)
                 playerData->player.endShotShieldCredit = 1;
         }
 
@@ -5247,7 +5247,7 @@ static void handleCommand(int t, void *rawbuf, bool udp)
 
         FlagInfo *toFlag = FlagInfo::get(toPlayersFlag);
         // without flag or with a non thief flag? Then is probably cheating
-        if (!toFlag || toFlag->flag.type != Flags::Thief)
+        if (!toFlag || toFlag->flag.type->flagEffect != FlagEffect::Thief)
             cheater = true;
 
         // TODO, check thief radius here
@@ -5533,13 +5533,13 @@ static void handleCommand(int t, void *rawbuf, bool udp)
                     if (pFlag >= 0)
                     {
                         FlagInfo &flag = *FlagInfo::get(pFlag);
-                        if (flag.flag.type == Flags::Velocity)
+                        if (flag.flag.type->flagEffect == FlagEffect::Velocity)
                             maxPlanarSpeed *= BZDB.eval(StateDatabase::BZDB_VELOCITYAD);
-                        else if (flag.flag.type == Flags::Thief)
+                        else if (flag.flag.type->flagEffect == FlagEffect::Thief)
                             maxPlanarSpeed *= BZDB.eval(StateDatabase::BZDB_THIEFVELAD);
-                        else if (flag.flag.type == Flags::Agility)
+                        else if (flag.flag.type->flagEffect == FlagEffect::Agility)
                             maxPlanarSpeed *= BZDB.eval(StateDatabase::BZDB_AGILITYADVEL);
-                        else if ((flag.flag.type == Flags::Burrow) &&
+                        else if ((flag.flag.type->flagEffect == FlagEffect::Burrow) &&
                                  (playerData->lastState.pos[2] == state.pos[2]) &&
                                  (playerData->lastState.velocity[2] == state.velocity[2]) &&
                                  (state.pos[2] <= BZDB.eval(StateDatabase::BZDB_BURROWDEPTH)))

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -4493,9 +4493,7 @@ BZF_API const char* bz_getProtocolVersion ( void )
     return getProtocolVersion();
 }
 
-BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name,
-                                   const char* help, bz_eShotType shotType,
-                                   bz_eFlagQuality quality)
+BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name, const char* help, int shotType, uint8_t quality)
 {
     // require defined fields
     if (!abbr || !name || !help)
@@ -4511,12 +4509,12 @@ BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name,
         return false;
 
     FlagEndurance e = FlagEndurance::Unstable;
-    switch (quality)
+    switch ((bz_eFlagQuality)quality)
     {
-    case eGoodFlag:
+    case bz_eFlagQuality::Good:
         e = FlagEndurance::Unstable;
         break;
-    case eBadFlag:
+    case bz_eFlagQuality::Bad:
         e = FlagEndurance::Sticky;
         break;
     default:
@@ -4526,7 +4524,7 @@ BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name,
     /* let this pointer dangle.  the constructor has taken care of all
      * the real work on the server side.
      */
-    FlagType::Ptr tmp = Flags::AddCustomFlag(std::make_shared<FlagType>(name, abbr, e, (ShotType)shotType, (FlagQuality)quality, NoTeam, help, true));
+    FlagType::Ptr tmp = Flags::AddCustomFlag(std::make_shared<FlagType>(name, abbr, e, (ShotType)shotType, (FlagQuality)quality, NoTeam, FlagEffect::Normal, help, true));
 
     /* default the shot limit.  note that -sl will still take effect, if
      * this plugin is loaded from the command line or config file, since
@@ -4543,6 +4541,89 @@ BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name,
     char* bufStart = buf;
     buf = (char*)tmp->packCustom(buf);
     broadcastMessage(MsgFlagType, buf-bufStart, bufStart);
+
+    return true;
+}
+
+BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name, char* helpString, bz_eFlagQuality quality, bz_FlagEffect effect , bz_eTeamType teamColor)
+{
+    // require defined fields
+    if (abbr == nullptr || name == nullptr || helpString == nullptr)
+        return false;
+
+    // length limits
+    if ((strlen(abbr) > 2) || (strlen(name) > 32) || (strlen(helpString) > 128))
+        return false;
+
+    // don't register an existing flag (i.e. can't override builtins)
+    auto flagType = FlagType::getDescFromAbbreviation(abbr);
+    if (flagType != Flags::Null)
+        return false;
+
+    FlagEndurance e = FlagEndurance::Unstable;
+    switch (quality)
+    {
+    case bz_eFlagQuality::Good:
+        e = FlagEndurance::Unstable;
+        break;
+    case bz_eFlagQuality::Bad:
+        e = FlagEndurance::Sticky;
+        break;
+    default:
+        return false; // shouldn't happen
+    }
+
+    if (teamColor > ePurpleTeam || teamColor == eRogueTeam)
+        teamColor = eNoTeam;
+
+    if (teamColor != eNoTeam)
+    {
+        e = FlagEndurance::Unstable;
+        quality = bz_eFlagQuality::Good;
+    }
+
+    ShotType shotType = ShotType::Normal;
+
+    switch (effect)
+    {
+        case bz_FlagEffect::RapidFire:
+        case bz_FlagEffect::MachineGun:
+        case bz_FlagEffect::GuidedMissile:
+        case bz_FlagEffect::Laser:
+        case bz_FlagEffect::Ricochet:
+        case bz_FlagEffect::SuperBullet:
+        case bz_FlagEffect::InvisibleBullet:
+        case bz_FlagEffect::Steamroller:
+        case bz_FlagEffect::ShockWave:
+        case bz_FlagEffect::PhantomZone:
+        case bz_FlagEffect::Thief:
+            shotType = ShotType::Special;
+            break;
+    
+        default:
+            break;
+    }
+
+    /* let this pointer dangle.  the constructor has taken care of all
+    * the real work on the server side.
+    */
+    FlagType::Ptr tmp = Flags::AddCustomFlag(std::make_shared<FlagType>(name, abbr, e, shotType, (FlagQuality)quality, (TeamColor)convertTeam(teamColor), (FlagEffect)effect, helpString, true));
+
+    /* default the shot limit.  note that -sl will still take effect, if
+    * this plugin is loaded from the command line or config file, since
+    * it's processed in finalization
+    */
+    clOptions->flagLimit[tmp] = -1;
+
+    /* notify existing players (if any) about the new flag type.  this
+    * behavior is a bit questionable, but seems to be the Right
+    * Thing(tm) to do.  new clients will get the notification during
+    * flag negotiation, which is better.
+    */
+    char* buf = getDirectMessageBuffer();
+    char* bufStart = buf;
+    buf = (char*)tmp->packCustom(buf);
+    broadcastMessage(MsgFlagType, buf - bufStart, bufStart);
 
     return true;
 }

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -4545,7 +4545,7 @@ BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name, const cha
     return true;
 }
 
-BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name, char* helpString, bz_eFlagQuality quality, bz_FlagEffect effect , bz_eTeamType teamColor)
+BZF_API bool bz_RegisterCustomFlag(const char* abbr, const char* name, const char* helpString, bz_eFlagQuality quality, bz_FlagEffect effect , bz_eTeamType teamColor)
 {
     // require defined fields
     if (abbr == nullptr || name == nullptr || helpString == nullptr)

--- a/src/common/Flag.cxx
+++ b/src/common/Flag.cxx
@@ -103,99 +103,99 @@ namespace Flags
 
     void init()
     {
-        Null    = AddStdFlag(std::make_shared<FlagType>( "", "", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, NoTeam, "" ));
+        Null    = AddStdFlag(std::make_shared<FlagType>( "", "", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Normal, "" ));
 
-        Unknown = AddStdFlag(std::make_shared<FlagType>("Unknown", "--", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Unknown = AddStdFlag(std::make_shared<FlagType>("Unknown", "--", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Normal,
                                     "A flag of an unknown type, pick it up and see what it is."));
-        RedTeam = AddStdFlag(std::make_shared<FlagType>( "Red Team", "R*", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, ::RedTeam,
+        RedTeam = AddStdFlag(std::make_shared<FlagType>( "Red Team", "R*", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, ::RedTeam, FlagEffect::Normal,
                                     "If it's yours, prevent other teams from taking it.  If it's not take it to your base to capture it!" ));
-        GreenTeam   = AddStdFlag(std::make_shared<FlagType>( "Green Team", "G*", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, ::GreenTeam,
+        GreenTeam   = AddStdFlag(std::make_shared<FlagType>( "Green Team", "G*", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, ::GreenTeam, FlagEffect::Normal,
                                     "If it's yours, prevent other teams from taking it.  If it's not take it to your base to capture it!" ));
-        BlueTeam    = AddStdFlag(std::make_shared<FlagType>( "Blue Team", "B*", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, ::BlueTeam,
+        BlueTeam    = AddStdFlag(std::make_shared<FlagType>( "Blue Team", "B*", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, ::BlueTeam, FlagEffect::Normal,
                                     "If it's yours, prevent other teams from taking it.  If it's not take it to your base to capture it!" ));
-        PurpleTeam  = AddStdFlag(std::make_shared<FlagType>( "Purple Team", "P*", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, ::PurpleTeam,
+        PurpleTeam  = AddStdFlag(std::make_shared<FlagType>( "Purple Team", "P*", FlagEndurance::Normal, ShotType::Normal, FlagQuality::Good, ::PurpleTeam, FlagEffect::Normal,
                                     "If it's yours, prevent other teams from taking it.  If it's not take it to your base to capture it!" ));
-        Velocity    = AddStdFlag(std::make_shared<FlagType>( "High Speed", "V", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Velocity    = AddStdFlag(std::make_shared<FlagType>( "High Speed", "V", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Velocity,
                                     "Tank moves faster.  Outrun bad guys." ));
-        QuickTurn   = AddStdFlag(std::make_shared<FlagType>( "Quick Turn", "QT", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        QuickTurn   = AddStdFlag(std::make_shared<FlagType>( "Quick Turn", "QT", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::QuickTurn,
                                     "Tank turns faster.  Good for dodging." ));
-        OscillationOverthruster = AddStdFlag(std::make_shared<FlagType>( "Oscillation Overthruster", "OO", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        OscillationOverthruster = AddStdFlag(std::make_shared<FlagType>( "Oscillation Overthruster", "OO", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::OscillationOverthruster,
                                     "Can drive through buildings.  Can't back up or shoot while inside." ));
-        RapidFire   = AddStdFlag(std::make_shared<FlagType>( "Rapid Fire", "F", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam,
+        RapidFire   = AddStdFlag(std::make_shared<FlagType>( "Rapid Fire", "F", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam, FlagEffect::RapidFire,
                                     "Shoots more often.  Shells go faster but not as far." ));
-        MachineGun  = AddStdFlag(std::make_shared<FlagType>( "Machine Gun", "MG", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam,
+        MachineGun  = AddStdFlag(std::make_shared<FlagType>( "Machine Gun", "MG", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam, FlagEffect::MachineGun,
                                     "Very fast reload and very short range." ));
-        GuidedMissile   = AddStdFlag(std::make_shared<FlagType>( "Guided Missile", "GM", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam,
+        GuidedMissile   = AddStdFlag(std::make_shared<FlagType>( "Guided Missile", "GM", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam, FlagEffect::GuidedMissile,
                                     "Shots track a target.  Lock on with right button.  Can lock on or retarget after firing." ));
-        Laser   = AddStdFlag(std::make_shared<FlagType>( "Laser", "L", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam,
+        Laser   = AddStdFlag(std::make_shared<FlagType>( "Laser", "L", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam, FlagEffect::Laser,
                                     "Shoots a laser.  Infinite speed and range but long reload time."));
-        Ricochet    = AddStdFlag(std::make_shared<FlagType>( "Ricochet", "R", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam,
+        Ricochet    = AddStdFlag(std::make_shared<FlagType>( "Ricochet", "R", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam, FlagEffect::Ricochet,
                                     "Shots bounce off walls.  Don't shoot yourself!" ));
-        SuperBullet = AddStdFlag(std::make_shared<FlagType>( "Super Bullet", "SB", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam,
+        SuperBullet = AddStdFlag(std::make_shared<FlagType>( "Super Bullet", "SB", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam, FlagEffect::SuperBullet,
                                     "Shoots through buildings.  Can kill Phantom Zone." ));
-        InvisibleBullet = AddStdFlag(std::make_shared<FlagType>( "Invisible Bullet", "IB", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        InvisibleBullet = AddStdFlag(std::make_shared<FlagType>( "Invisible Bullet", "IB", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::InvisibleBullet,
                                     "Your shots don't appear on other radars.  Can still see them out window."));
-        Stealth = AddStdFlag(std::make_shared<FlagType>( "Stealth", "ST", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Stealth = AddStdFlag(std::make_shared<FlagType>( "Stealth", "ST", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Stealth,
                                     "Tank is invisible on radar.  Shots are still visible.  Sneak up behind enemies!"));
-        Tiny    = AddStdFlag(std::make_shared<FlagType>( "Tiny", "T", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Tiny    = AddStdFlag(std::make_shared<FlagType>( "Tiny", "T", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Tiny,
                                     "Tank is small and can get through small openings.  Very hard to hit." ));
-        Narrow  = AddStdFlag(std::make_shared<FlagType>( "Narrow", "N", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Narrow  = AddStdFlag(std::make_shared<FlagType>( "Narrow", "N", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Narrow,
                                     "Tank is super thin.  Very hard to hit from front but is normal size from side.  Can get through small openings."));
-        Shield  = AddStdFlag(std::make_shared<FlagType>( "Shield", "SH", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Shield  = AddStdFlag(std::make_shared<FlagType>( "Shield", "SH", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Shield,
                                     "Getting hit only drops flag.  Flag flies an extra-long time."));
-        Steamroller = AddStdFlag(std::make_shared<FlagType>( "Steamroller", "SR", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Steamroller = AddStdFlag(std::make_shared<FlagType>( "Steamroller", "SR", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Steamroller,
                                     "Destroys tanks you touch but you have to get really close."));
-        ShockWave   = AddStdFlag(std::make_shared<FlagType>( "Shock Wave", "SW", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam,
+        ShockWave   = AddStdFlag(std::make_shared<FlagType>( "Shock Wave", "SW", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam, FlagEffect::ShockWave,
                                     "Firing destroys all tanks nearby.  Don't kill teammates!  Can kill tanks on/in buildings."));
-        PhantomZone = AddStdFlag(std::make_shared<FlagType>( "Phantom Zone", "PZ", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam,
+        PhantomZone = AddStdFlag(std::make_shared<FlagType>( "Phantom Zone", "PZ", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam, FlagEffect::PhantomZone,
                                     "Teleporting toggles Zoned effect.  Zoned tank can drive through buildings.  Zoned tank shoots Zoned bullets and can't be shot (except by superbullet, shock wave, and other Zoned tanks)."));
-        Jumping = AddStdFlag(std::make_shared<FlagType>( "Jumping", "JP", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Jumping = AddStdFlag(std::make_shared<FlagType>( "Jumping", "JP", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Jumping,
                                     "Tank can jump.  Use Tab key.  Can't steer in the air."));
-        Identify    = AddStdFlag(std::make_shared<FlagType>( "Identify", "ID", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Identify    = AddStdFlag(std::make_shared<FlagType>( "Identify", "ID", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Identify,
                                     "Identifies type of nearest flag."));
-        Cloaking    = AddStdFlag(std::make_shared<FlagType>( "Cloaking", "CL", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Cloaking    = AddStdFlag(std::make_shared<FlagType>( "Cloaking", "CL", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Cloaking,
                                     "Makes your tank invisible out-the-window.  Still visible on radar."));
-        Useless = AddStdFlag(std::make_shared<FlagType>( "Useless", "US", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Useless = AddStdFlag(std::make_shared<FlagType>( "Useless", "US", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Useless,
                                     "You have found the useless flag. Use it wisely."));
-        Masquerade  = AddStdFlag(std::make_shared<FlagType>( "Masquerade", "MQ", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Masquerade  = AddStdFlag(std::make_shared<FlagType>( "Masquerade", "MQ", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Masquerade,
                                     "In opponent's hud, you appear as a teammate."));
-        Seer    = AddStdFlag(std::make_shared<FlagType>( "Seer", "SE", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Seer    = AddStdFlag(std::make_shared<FlagType>( "Seer", "SE", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Seer,
                                     "See stealthed, cloaked and masquerading tanks as normal."));
-        Thief   = AddStdFlag(std::make_shared<FlagType>( "Thief", "TH", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam,
+        Thief   = AddStdFlag(std::make_shared<FlagType>( "Thief", "TH", FlagEndurance::Unstable, ShotType::Special, FlagQuality::Good, NoTeam, FlagEffect::Thief,
                                     "Steal flags.  Small and fast but can't kill."));
-        Burrow  = AddStdFlag(std::make_shared<FlagType>( "Burrow", "BU", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Burrow  = AddStdFlag(std::make_shared<FlagType>( "Burrow", "BU", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Burrow,
                                     "Tank burrows underground, impervious to normal shots, but can be steamrolled by anyone!"));
-        Wings   = AddStdFlag(std::make_shared<FlagType>( "Wings", "WG", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Wings   = AddStdFlag(std::make_shared<FlagType>( "Wings", "WG", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Wings,
                                     "Tank can drive in air."));
-        Agility = AddStdFlag(std::make_shared<FlagType>( "Agility", "A", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam,
+        Agility = AddStdFlag(std::make_shared<FlagType>( "Agility", "A", FlagEndurance::Unstable, ShotType::Normal, FlagQuality::Good, NoTeam, FlagEffect::Agility,
                                     "Tank is quick and nimble making it easier to dodge."));
-        ReverseControls = AddStdFlag(std::make_shared<FlagType>( "ReverseControls", "RC", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        ReverseControls = AddStdFlag(std::make_shared<FlagType>( "ReverseControls", "RC", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::ReverseControls,
                                     "Tank driving controls are reversed."));
-        Colorblindness  = AddStdFlag(std::make_shared<FlagType>( "Colorblindness", "CB", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        Colorblindness  = AddStdFlag(std::make_shared<FlagType>( "Colorblindness", "CB", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::Colorblindness,
                                     "Can't tell team colors.  Don't shoot teammates!"));
-        Obesity = AddStdFlag(std::make_shared<FlagType>( "Obesity", "O", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        Obesity = AddStdFlag(std::make_shared<FlagType>( "Obesity", "O", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::Obesity,
                                     "Tank becomes very large.  Can't fit through teleporters."));
-        LeftTurnOnly    = AddStdFlag(std::make_shared<FlagType>( "Left Turn Only", "LT", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        LeftTurnOnly    = AddStdFlag(std::make_shared<FlagType>( "Left Turn Only", "LT", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::LeftTurnOnly,
                                     "Can't turn right."));
-        RightTurnOnly   = AddStdFlag(std::make_shared<FlagType>( "Right Turn Only", "RT", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        RightTurnOnly   = AddStdFlag(std::make_shared<FlagType>( "Right Turn Only", "RT", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::RightTurnOnly,
                                     "Can't turn left."));
-        ForwardOnly = AddStdFlag(std::make_shared<FlagType>( "Forward Only", "FO", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        ForwardOnly = AddStdFlag(std::make_shared<FlagType>( "Forward Only", "FO", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::ForwardOnly,
                                     "Can't drive in reverse."));
-        ReverseOnly = AddStdFlag(std::make_shared<FlagType>( "ReverseOnly", "RO", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        ReverseOnly = AddStdFlag(std::make_shared<FlagType>( "ReverseOnly", "RO", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::ReverseOnly,
                                     "Can't drive forward."));
-        Momentum    = AddStdFlag(std::make_shared<FlagType>( "Momentum", "M", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        Momentum    = AddStdFlag(std::make_shared<FlagType>( "Momentum", "M", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::Momentum,
                                     "Tank has inertia.  Acceleration is limited."));
-        Blindness   = AddStdFlag(std::make_shared<FlagType>( "Blindness", "B", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        Blindness   = AddStdFlag(std::make_shared<FlagType>( "Blindness", "B", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::Blindness,
                                     "Can't see out window.  Radar still works."));
-        Jamming = AddStdFlag(std::make_shared<FlagType>( "Jamming", "JM", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        Jamming = AddStdFlag(std::make_shared<FlagType>( "Jamming", "JM", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::Jamming,
                                     "Radar doesn't work.  Can still see."));
-        WideAngle   = AddStdFlag(std::make_shared<FlagType>( "Wide Angle", "WA", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        WideAngle   = AddStdFlag(std::make_shared<FlagType>( "Wide Angle", "WA", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::WideAngle,
                                     "Fish-eye lens distorts view."));
-        NoJumping   = AddStdFlag(std::make_shared<FlagType>( "No Jumping", "NJ", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        NoJumping   = AddStdFlag(std::make_shared<FlagType>( "No Jumping", "NJ", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::NoJumping,
                                     "Tank can't jump."));
-        TriggerHappy    = AddStdFlag(std::make_shared<FlagType>( "Trigger Happy", "TR", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        TriggerHappy    = AddStdFlag(std::make_shared<FlagType>( "Trigger Happy", "TR", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::TriggerHappy,
                                     "Tank can't stop firing."));
-        Bouncy  = AddStdFlag(std::make_shared<FlagType>( "Bouncy", "BY", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam,
+        Bouncy  = AddStdFlag(std::make_shared<FlagType>( "Bouncy", "BY", FlagEndurance::Sticky, ShotType::Normal, FlagQuality::Bad, NoTeam, FlagEffect::Bouncy,
                                     "Tank can't stop bouncing."));
     }
 
@@ -303,6 +303,7 @@ void* FlagType::packCustom(void* buf) const
     buf = pack(buf);
     buf = nboPackUByte(buf, uint8_t(flagQuality));
     buf = nboPackUByte(buf, uint8_t(flagShot));
+    buf = nboPackUByte(buf, uint8_t(flagEffect));
     buf = nboPackStdString(buf, flagName);
     buf = nboPackStdString(buf, flagHelp);
     return buf;
@@ -315,10 +316,10 @@ const void* FlagType::unpackCustom(const void* buf, FlagType::Ptr &type)
     buf = nboUnpackUByte(buf, abbv[0]);
     buf = nboUnpackUByte(buf, abbv[1]);
 
-    uint8_t quality, shot;
+    uint8_t quality, shot, effect;
     buf = nboUnpackUByte(buf, quality);
     buf = nboUnpackUByte(buf, shot);
-
+    buf = nboUnpackUByte(buf, effect);
     // make copies to keep - note that these will need to be deleted.
     std::string sName, sHelp;
     buf = nboUnpackStdString(buf, sName);
@@ -337,8 +338,7 @@ const void* FlagType::unpackCustom(const void* buf, FlagType::Ptr &type)
         assert(false); // shouldn't happen
     }
 
-    type = Flags::AddCustomFlag(std::make_shared<FlagType>(sName, reinterpret_cast<const char*>(&abbv[0]),
-                        e, (ShotType)shot, (FlagQuality)quality, NoTeam, sHelp, true));
+    type = Flags::AddCustomFlag(std::make_shared<FlagType>(sName, reinterpret_cast<const char*>(&abbv[0]), e, (ShotType)shot, (FlagQuality)quality, NoTeam, (FlagEffect)effect, sHelp, true));
     return buf;
 }
 


### PR DESCRIPTION
Effects now come from a dedicated effect field not checking the flag type against a preset list of object pointers.
Custom flags send the type over the wire.
Team flag effects check the flag team color not the type pointer.
Added NoShot effect that sends a fire shot message to the server but does not create local or remote shots to allow the server to handle the entire shot process (such as for mines or other custom effects).