### PR TITLE
Make mouse wheel work like a mouse button by always giving an "up" event

### DIFF
--- a/include/BzfDisplay.h
+++ b/include/BzfDisplay.h
@@ -29,8 +29,8 @@ public:
 
     virtual bool    isValid() const = 0;
     virtual bool    isEventPending() const = 0;
-    virtual bool    getEvent(BzfEvent&) const = 0;
-    virtual bool    peekEvent(BzfEvent&) const = 0;
+    virtual bool    getEvent(BzfEvent&) = 0;
+    virtual bool    peekEvent(BzfEvent&) = 0;
 
     virtual bool    hasGetKeyMode()
     {

--- a/src/common/KeyManager.cxx
+++ b/src/common/KeyManager.cxx
@@ -199,8 +199,7 @@ KeyManager::~KeyManager()
 {
 }
 
-void            KeyManager::bind(const BzfKeyEvent& key,
-                                 bool press, const std::string& cmd)
+void            KeyManager::bind(const BzfKeyEvent& key, bool press, const std::string& cmd)
 {
     if (press)
     {
@@ -260,8 +259,7 @@ void            KeyManager::unbindCommand(const char* command)
 std::string     KeyManager::get(const BzfKeyEvent& key,
                                 bool press) const
 {
-    const EventToCommandMap* map = press ? &pressEventToCommand :
-                                   &releaseEventToCommand;
+    const EventToCommandMap* map = press ? &pressEventToCommand : &releaseEventToCommand;
     // If this key has both a button and an ascii value, search the hard way
     if (key.ascii != '\0' && key.button != BzfKeyEvent::NoButton)
     {

--- a/src/platform/SDL2Display.h
+++ b/src/platform/SDL2Display.h
@@ -26,6 +26,7 @@
 
 // system interface headers
 #include <map>
+#include <deque>
 
 class SDLDisplay : public BzfDisplay
 {
@@ -37,8 +38,8 @@ public:
         return true;
     };
     bool isEventPending() const;
-    bool getEvent(BzfEvent&) const;
-    bool peekEvent(BzfEvent&) const;
+    bool getEvent(BzfEvent&);
+    bool peekEvent(BzfEvent&);
     bool getKey(const SDL_Event& sdlEvent, BzfKeyEvent& key, const char asciiText = '\0') const;
     void getWindowSize(int& width, int& height);
     bool hasGetKeyMode()
@@ -47,7 +48,7 @@ public:
     };
     void getModState(bool &shift, bool &control, bool &alt);
 private:
-    bool setupEvent(BzfEvent&, const SDL_Event&) const;
+    bool setupEvent(BzfEvent&, const SDL_Event&);
     bool doSetResolution(int)
     {
         return true;
@@ -56,6 +57,8 @@ private:
     int  min_height;
     int  x;
     int  y;
+
+    std::deque<int> pendingUpEvents;
 };
 
 #endif // BZF_SDLDISPLAY_H

--- a/src/platform/WinDisplay.h
+++ b/src/platform/WinDisplay.h
@@ -18,7 +18,9 @@
 #define BZF_WINDISPLAY_H
 #include "common.h"
 #include "BzfDisplay.h"
+#include "BzfEvent.h"
 #include "bzfgl.h"
+#include <deque>
 
 class BzfKeyEvent;
 class Resolution;
@@ -32,7 +34,7 @@ public:
 
     virtual bool    isValid() const;
     bool        isEventPending() const;
-    bool        getEvent(BzfEvent&) const;
+    bool        getEvent(BzfEvent&);
     bool        hasGetKeyMode()
     {
         return true;
@@ -45,7 +47,7 @@ public:
     int         getFullWidth() const;
     int         getFullHeight() const;
 
-    bool        peekEvent(BzfEvent& event) const;
+    bool        peekEvent(BzfEvent& event);
 
 
     // for other Windows stuff
@@ -101,6 +103,8 @@ private:
     static const int    asciiMap[];
     static const int    asciiShiftMap[];
     static const int    buttonMap[];
+
+    std::deque<int> pendingUpEvents;
 };
 
 #endif // BZF_WINDISPLAY_H


### PR DESCRIPTION
make mouse wheel events always produce a "up" event after a "down" event, since they can't be held.
Solves issue #165 