### PR TITLE
make server use a pool of network buffers

### DIFF
--- a/MSVC/build/bzfs.vcxproj
+++ b/MSVC/build/bzfs.vcxproj
@@ -391,6 +391,7 @@ copy "$(BZ_DEPS)\output-$(Configuration)-$(PlatformShortName)\bin\*.dll" "..\..\
     <ClCompile Include="..\..\src\bzfs\GameKeeper.cxx" />
     <ClCompile Include="..\..\src\bzfs\ListServerConnection.cxx" />
     <ClCompile Include="..\..\src\bzfs\MasterBanList.cxx" />
+    <ClCompile Include="..\..\src\bzfs\MessagBuffers.cxx" />
     <ClCompile Include="..\..\src\bzfs\ParseMaterial.cxx" />
     <ClCompile Include="..\..\src\bzfs\Permissions.cxx">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
@@ -685,6 +686,7 @@ copy "$(BZ_DEPS)\output-$(Configuration)-$(PlatformShortName)\bin\*.dll" "..\..\
     <ClInclude Include="..\..\src\bzfs\GameKeeper.h" />
     <ClInclude Include="..\..\src\bzfs\ListServerConnection.h" />
     <ClInclude Include="..\..\src\bzfs\MasterBanList.h" />
+    <ClInclude Include="..\..\src\bzfs\MessageBuffers.h" />
     <ClInclude Include="..\..\src\bzfs\PackVars.h" />
     <ClInclude Include="..\..\src\bzfs\ParseMaterial.h" />
     <ClInclude Include="..\..\src\bzfs\Permissions.h" />

--- a/MSVC/build/bzfs.vcxproj.filters
+++ b/MSVC/build/bzfs.vcxproj.filters
@@ -181,6 +181,9 @@
     <ClCompile Include="..\..\src\bzfs\bzfsAPIWorld.cxx">
       <Filter>Source Files\API</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\bzfs\MessagBuffers.cxx">
+      <Filter>Source Files\Server</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\bzfs\CustomArc.h">
@@ -360,6 +363,9 @@
     </ClInclude>
     <ClInclude Include="..\..\include\bzfsAPIWorld.h">
       <Filter>Header Files\API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bzfs\MessageBuffers.h">
+      <Filter>Header Files\Server</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/plugins/changeTeam/changeTeam.cpp
+++ b/plugins/changeTeam/changeTeam.cpp
@@ -76,7 +76,7 @@ public:
     }
 
     if (newTeam != eNoTeam)
-      bz_changeTeam(playerID, newTeam);
+      bz_changePlayerTeam(playerID, newTeam);
 
     return true;
   }

--- a/src/bzfs/GameKeeper.h
+++ b/src/bzfs/GameKeeper.h
@@ -86,9 +86,9 @@ public:
         static void     reloadAccessDatabase();
 
         bool            loadEnterData(uint16_t& rejectCode, char* rejectMsg);
-        void*           packAdminInfo(void* buf);
-        void*           packPlayerInfo(void* buf);
-        void*           packPlayerUpdate(void* buf);
+        void            packAdminInfo(MessageBuffer::Ptr msg);
+        void            packPlayerInfo(MessageBuffer::Ptr msg);
+        void            packPlayerUpdate(MessageBuffer::Ptr msg);
 
         void            setPlayerAddMessage(PlayerAddMessage &msg);
 
@@ -394,7 +394,7 @@ inline GameKeeper::Player* GameKeeper::Player::getPlayerByIndex(int
     return playerList[_playerIndex];
 }
 
-void* PackPlayerInfo(void* buf, int playerIndex, uint8_t properties );
+void PackPlayerInfo(MessageBuffer::Ptr msg, int playerIndex, uint8_t properties );
 
 // For hostban checking, to avoid check and check again
 inline void GameKeeper::Player::setAllNeedHostbanChecked(bool set)

--- a/src/bzfs/Makefile.am
+++ b/src/bzfs/Makefile.am
@@ -93,6 +93,8 @@ bzfs_SOURCES =				\
 	ListServerConnection.h		\
 	MasterBanList.cxx		\
 	MasterBanList.h			\
+	MessagBuffers.h			\
+	MessagBuffers.cxx			\
 	PackVars.h			\
 	ParseMaterial.cxx		\
 	ParseMaterial.h			\

--- a/src/bzfs/MessagBuffers.cxx
+++ b/src/bzfs/MessagBuffers.cxx
@@ -35,7 +35,7 @@ void MessageBuffer::reset()
 
 size_t MessageBuffer::size()
 {
-    return (size_t)((unsigned char*)write_ptr - raw_buffer - (2 * sizeof(uint16_t)));
+    return (size_t)(((unsigned char*)write_ptr - raw_buffer) - (2 * sizeof(uint16_t)));
 }
 
 void* MessageBuffer::buffer()
@@ -159,5 +159,9 @@ MessageBuffer::Ptr GetMessageBuffer()
 void ReleaseMessageBuffer(MessageBuffer::Ptr buffer)
 {
     if (buffer != nullptr)
+    {
+        buffer->reset();
         buffer->locked = false;
-}
+    }
+ }
+        

--- a/src/bzfs/MessagBuffers.cxx
+++ b/src/bzfs/MessagBuffers.cxx
@@ -43,6 +43,29 @@ void* MessageBuffer::buffer()
     return raw_buffer;
 }
 
+void* MessageBuffer::current_buffer()
+{
+    return write_ptr;
+}
+
+void MessageBuffer::push_repack(size_t offset)
+{
+    saved_ptr = write_ptr;
+    write_ptr = ((unsigned char*)raw_buffer) + offset + 4;
+}
+
+void MessageBuffer::pop_offset()
+{
+    write_ptr = saved_ptr;
+    saved_ptr = nullptr;
+}
+
+
+void MessageBuffer::legacyPack(void* newEndPtr)
+{
+    write_ptr = newEndPtr;
+}
+
 void MessageBuffer::packUByte(uint8_t val)
 {
     write_ptr = nboPackUByte(write_ptr, val);

--- a/src/bzfs/MessagBuffers.cxx
+++ b/src/bzfs/MessagBuffers.cxx
@@ -1,0 +1,128 @@
+/* bzflag
+* Copyright (c) 1993-2018 Tim Riker
+*
+* This package is free software;  you can redistribute it and/or
+* modify it under the terms of the license found in the file
+* named COPYING that should have accompanied this file.
+*
+* THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+#include "MessageBuffers.h"
+#include "Protocol.h"
+#include "pack.h"
+
+#include <vector>
+
+MessageBuffer::MessageBuffer()
+{
+    raw_buffer = new unsigned char[MaxPacketLen];
+    reset();
+}
+
+MessageBuffer::~MessageBuffer()
+{
+    if (raw_buffer != nullptr)
+        delete[] raw_buffer;
+}
+
+void MessageBuffer::reset()
+{
+    write_ptr = &(raw_buffer[2 * sizeof(uint16_t)]);
+}
+
+size_t MessageBuffer::size()
+{
+    return (size_t)((unsigned char*)write_ptr - raw_buffer - (2 * sizeof(uint16_t)));
+}
+
+void* MessageBuffer::buffer()
+{
+    return raw_buffer;
+}
+
+void MessageBuffer::packUByte(uint8_t val)
+{
+    write_ptr = nboPackUByte(write_ptr, val);
+}
+
+void MessageBuffer::packShort(int16_t val)
+{
+    write_ptr = nboPackShort(write_ptr, val);
+}
+
+void MessageBuffer::packInt(int32_t val)
+{
+    write_ptr = nboPackInt(write_ptr, val);
+}
+
+void MessageBuffer::packUShort(uint16_t val)
+{
+    write_ptr = nboPackUShort(write_ptr, val);
+}
+
+void MessageBuffer::packUInt(uint32_t val)
+{
+    write_ptr = nboPackUInt(write_ptr, val);
+}
+
+void MessageBuffer::packFloat(float val)
+{
+    write_ptr = nboPackFloat(write_ptr, val);
+}
+
+void MessageBuffer::packVector(const float* val)
+{
+    write_ptr = nboPackVector(write_ptr, val);
+}
+
+void MessageBuffer::packString(const void* val, int len)
+{
+    write_ptr = nboPackString(write_ptr, val, len);
+}
+
+void MessageBuffer::packStdString(const std::string& val)
+{
+    write_ptr = nboPackStdString(write_ptr, val);
+}
+
+std::vector<MessageBuffer::Ptr> BufferPool;
+
+void moreBuffers()
+{
+    for (int i = 0; i < 5; i++)
+        BufferPool.push_back(std::make_shared<MessageBuffer>());
+}
+
+MessageBuffer::Ptr checkOutBuffer()
+{
+    for (size_t i = 0; i < BufferPool.size(); i++)
+    {
+        if (!BufferPool[i]->locked)
+        {
+            BufferPool[i]->locked = true;
+            return BufferPool[i];
+        }
+    }
+
+    return nullptr;
+}
+
+MessageBuffer::Ptr GetMessageBuffer()
+{
+    auto buffer = checkOutBuffer();
+    if (buffer == nullptr)
+    {
+        moreBuffers();
+        buffer = checkOutBuffer();
+    }
+    return buffer;
+}
+
+void ReleaseMessageBuffer(MessageBuffer::Ptr buffer)
+{
+    if (buffer != nullptr)
+        buffer->locked = false;
+}

--- a/src/bzfs/MessagBuffers.cxx
+++ b/src/bzfs/MessagBuffers.cxx
@@ -48,6 +48,12 @@ void* MessageBuffer::current_buffer()
     return write_ptr;
 }
 
+void* MessageBuffer::record_buffer()
+{
+    return (char*)raw_buffer + 4;;
+}
+
+
 void MessageBuffer::push_repack(size_t offset)
 {
     saved_ptr = write_ptr;
@@ -64,6 +70,12 @@ void MessageBuffer::pop_offset()
 void MessageBuffer::legacyPack(void* newEndPtr)
 {
     write_ptr = newEndPtr;
+}
+
+void MessageBuffer::packBuffer(const void* data, size_t len)
+{
+    memcpy(write_ptr, data, len);
+    write_ptr = (char*)write_ptr + len;
 }
 
 void MessageBuffer::packUByte(uint8_t val)

--- a/src/bzfs/MessageBuffers.h
+++ b/src/bzfs/MessageBuffers.h
@@ -34,6 +34,7 @@ public:
     void packStdString(const std::string& str);
 
     void legacyPack(void* newEndPtr);
+    void packBuffer(const void* data, size_t len);
 
     void reset();
 
@@ -41,6 +42,7 @@ public:
     void* buffer();
 
     void* current_buffer();
+    void* record_buffer();
 
     void push_repack(size_t offset);
     void pop_offset();

--- a/src/bzfs/MessageBuffers.h
+++ b/src/bzfs/MessageBuffers.h
@@ -1,0 +1,51 @@
+/* bzflag
+* Copyright (c) 1993-2018 Tim Riker
+*
+* This package is free software;  you can redistribute it and/or
+* modify it under the terms of the license found in the file
+* named COPYING that should have accompanied this file.
+*
+* THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+*/
+#pragma once
+
+#include "common.h"
+#include <string>
+#include <memory>
+
+class MessageBuffer
+{
+public:
+    typedef std::shared_ptr<MessageBuffer> Ptr;
+
+    MessageBuffer();
+    ~MessageBuffer();
+
+    void packUByte(uint8_t);
+    void packShort(int16_t);
+    void packInt(int32_t);
+    void packUShort(uint16_t);
+    void packUInt(uint32_t);
+    void packFloat(float);
+    void packVector(const float*);
+    void packString(const void* val, int len);
+    void packStdString(const std::string& str);
+
+    void reset();
+
+    size_t size();
+    void* buffer();
+
+    bool locked = false;
+
+protected:
+    unsigned char*   raw_buffer = nullptr;
+    void*   write_ptr;
+};
+
+MessageBuffer::Ptr GetMessageBuffer();
+void ReleaseMessageBuffer(MessageBuffer::Ptr buffer);
+
+

--- a/src/bzfs/MessageBuffers.h
+++ b/src/bzfs/MessageBuffers.h
@@ -33,16 +33,24 @@ public:
     void packString(const void* val, int len);
     void packStdString(const std::string& str);
 
+    void legacyPack(void* newEndPtr);
+
     void reset();
 
     size_t size();
     void* buffer();
 
+    void* current_buffer();
+
+    void push_repack(size_t offset);
+    void pop_offset();
+
     bool locked = false;
 
 protected:
     unsigned char*   raw_buffer = nullptr;
-    void*   write_ptr;
+    void*   write_ptr = nullptr;
+    void*   saved_ptr = nullptr;
 };
 
 MessageBuffer::Ptr GetMessageBuffer();

--- a/src/bzfs/PackVars.h
+++ b/src/bzfs/PackVars.h
@@ -39,7 +39,9 @@ public:
         if (len > sizeof(uint16_t))
         {
             nboPackUShort(bufStart, count);
-            directMessage(playerId, MsgSetVar, len, bufStart);
+            auto b = GetMessageBuffer();
+            b->packBuffer(bufStart, len);
+            sendPacket(playerId, MsgSetVar,b);
         }
     }
 
@@ -57,7 +59,11 @@ public:
         {
             nboPackUShort(bufStart, count);
             count = 0;
-            directMessage(playerId, MsgSetVar, len, bufStart);
+
+            auto b = GetMessageBuffer();
+            b->packBuffer(bufStart, len);
+            sendPacket(playerId, MsgSetVar, b);
+
             buf = nboPackUShort(bufStart, 0); //placeholder
             len = sizeof(uint16_t);
         }

--- a/src/bzfs/RecordReplay.cxx
+++ b/src/bzfs/RecordReplay.cxx
@@ -552,6 +552,11 @@ bool Record::addPacket(u16 code, int len, const void * data, u16 mode)
         return routePacket(code, len, data, mode);
 }
 
+bool Record::addPacket(uint16_t code, MessageBuffer::Ptr message, uint16_t mode = RealPacket)
+{
+    addPacket(code, message->size(), ((unsigned char*)message->buffer() + 4), mode);
+}
+
 
 static bool routePacket(u16 code, int len, const void * data, u16 mode)
 {

--- a/src/bzfs/RecordReplay.h
+++ b/src/bzfs/RecordReplay.h
@@ -150,7 +150,7 @@ static const unsigned int ReplayHeaderSize =
 // Some notes:
 //
 // - Any packets that get broadcast are buffered. Look for the
-//   Record::addPacket() hook in broadcastMessage(). For now,
+//   Record::addPacket() hook in broadcastPacket(). For now,
 //   it will not be mainting any information with regards to the
 //   state of the game during replay. It'll just be firing the
 //   packets back out the way that they came.

--- a/src/bzfs/RecordReplay.h
+++ b/src/bzfs/RecordReplay.h
@@ -17,6 +17,7 @@
 #include "common.h"
 #include "global.h"
 #include "Protocol.h"
+#include "MessageBuffers.h"
 
 const int ReplayObservers = 16;
 
@@ -49,8 +50,8 @@ extern bool enabled ();
 extern bool getAllowFileRecs();
 extern void setAllowFileRecs(bool value);
 
-extern bool addPacket (uint16_t code, int len, const void * data,
-                       uint16_t mode = RealPacket);
+extern bool addPacket (uint16_t code, int len, const void * data, uint16_t mode = RealPacket);
+extern bool addPacket(uint16_t code, MessageBuffer::Ptr message, uint16_t mode = RealPacket);
 
 extern void sendHelp (int playerIndex);
 }

--- a/src/bzfs/Score.cxx
+++ b/src/bzfs/Score.cxx
@@ -97,11 +97,19 @@ void Score::reset()
     changeScoreElement(bz_eTKs, &tks, 0);
 }
 
-void *Score::pack(MessageBuffer::Ptr message)
+void Score::pack(MessageBuffer::Ptr message)
 {
     message->packUShort(wins);
     message->packUShort(losses);
     message->packUShort(tks);
+}
+
+void*  Score::pack(void* buf)
+{
+    buf = nboPackUShort(buf, wins);
+    buf = nboPackUShort(buf, losses);
+    buf = nboPackUShort(buf, tks);
+    return buf;
 }
 
 bool Score::reached() const

--- a/src/bzfs/Score.cxx
+++ b/src/bzfs/Score.cxx
@@ -97,12 +97,11 @@ void Score::reset()
     changeScoreElement(bz_eTKs, &tks, 0);
 }
 
-void *Score::pack(void *buf)
+void *Score::pack(MessageBuffer::Ptr message)
 {
-    buf = nboPackUShort(buf, wins);
-    buf = nboPackUShort(buf, losses);
-    buf = nboPackUShort(buf, tks);
-    return buf;
+    message->packUShort(wins);
+    message->packUShort(losses);
+    message->packUShort(tks);
 }
 
 bool Score::reached() const

--- a/src/bzfs/Score.h
+++ b/src/bzfs/Score.h
@@ -17,6 +17,7 @@
 #include "global.h"
 
 #include "bzfsAPI.h"
+#include "MessageBuffers.h"
 
 class Score
 {
@@ -34,7 +35,7 @@ public:
     void  killedBy();
     void  kill();
     void  reset();
-    void *pack(void *buf);
+    void  pack(MessageBuffer::Ptr message);
     bool  reached() const;
     int   getWins() const
     {

--- a/src/bzfs/Score.h
+++ b/src/bzfs/Score.h
@@ -36,6 +36,7 @@ public:
     void  kill();
     void  reset();
     void  pack(MessageBuffer::Ptr message);
+    void*  pack(void* buf);
     bool  reached() const;
     int   getWins() const
     {

--- a/src/bzfs/ShotManager.cxx
+++ b/src/bzfs/ShotManager.cxx
@@ -26,6 +26,65 @@
 
 namespace Shots
 {
+    void PackShotUpdate(ShotUpdate &info, MessageBuffer::Ptr msg)
+    {
+        msg->packUByte(info.player);
+        msg->packUShort(info.id);
+        msg->packVector(info.pos);
+        msg->packVector(info.vel);
+        msg->packFloat(info.dt);
+        msg->packShort(info.team);
+    }
+
+    void PackFlagType(FlagType::Ptr info, MessageBuffer::Ptr msg)
+    {
+        msg->packUByte((info->flagAbbv.size() > 0) ? info->flagAbbv[0] : 0);
+        msg->packUByte((info->flagAbbv.size() > 1) ? info->flagAbbv[1] : 0);
+    }
+
+    void PackFirningInfo(FiringInfo &info, MessageBuffer::Ptr msg)
+    {
+        msg->packFloat(info.timeSent);
+        msg->packUShort((uint16_t)info.localID);
+        PackShotUpdate(info.shot,msg);
+        PackFlagType(info.flagType, msg);
+        msg->packFloat(info.lifetime);
+    }
+
+    void PackCustomFlagType(FlagType::Ptr info, MessageBuffer::Ptr msg)
+    {
+        PackFlagType(info, msg);
+        msg->packUByte(uint8_t(info->flagQuality));
+        msg->packUByte(uint8_t(info->flagShot));
+        msg->packUByte(uint8_t(info->flagEffect));
+        msg->packStdString(info->flagName);
+        msg->packStdString(info->flagHelp);
+    }
+
+    void PackFlag(FlagInfo& flag, bool hide, MessageBuffer::Ptr msg)
+    {
+        if (flag.flag.type->flagTeam != ::NoTeam)
+            hide = false;
+        if (flag.player != -1)
+            hide = false;
+        msg->packUShort(flag.getIndex());
+
+        if (hide)
+            PackFlagType(Flags::Unknown, msg);
+        else
+            PackFlagType(flag.flag.type, msg);
+
+        msg->packUShort(uint16_t(flag.flag.status));
+        msg->packUShort(uint16_t(flag.flag.endurance));
+        msg->packUByte(flag.flag.owner);
+        msg->packVector(flag.flag.position);
+        msg->packVector(flag.flag.launchPosition);
+        msg->packVector(flag.flag.landingPosition);
+        msg->packFloat(flag.flag.flightTime);
+        msg->packFloat(flag.flag.flightEnd);
+        msg->packFloat(flag.flag.initialVelocity);
+    }
+
     //----------------Manager
 
     double Manager::DeadShotCacheTime = 10.0;

--- a/src/bzfs/ShotManager.h
+++ b/src/bzfs/ShotManager.h
@@ -22,6 +22,7 @@
 #include "TimeKeeper.h"
 #include "FlagInfo.h"
 #include "Obstacle.h"
+#include "MessageBuffers.h"
 
 #include <string>
 #include <vector>

--- a/src/bzfs/ShotManager.h
+++ b/src/bzfs/ShotManager.h
@@ -20,7 +20,7 @@
 #include "ShotUpdate.h"
 #include "vectors.h"
 #include "TimeKeeper.h"
-
+#include "FlagInfo.h"
 #include "Obstacle.h"
 
 #include <string>
@@ -43,6 +43,12 @@
 
 namespace Shots
 {
+    void PackFirningInfo(FiringInfo &info, MessageBuffer::Ptr msg);
+    void PackShotUpdate(ShotUpdate &info, MessageBuffer::Ptr msg);
+    void PackFlagType(FlagType::Ptr info, MessageBuffer::Ptr msg);
+    void PackCustomFlagType(FlagType::Ptr info, MessageBuffer::Ptr msg);
+    void PackFlag(FlagInfo& flag, bool hide, MessageBuffer::Ptr msg);
+
     class Shot
     {
     protected:

--- a/src/bzfs/bzfs.h
+++ b/src/bzfs/bzfs.h
@@ -41,6 +41,7 @@
 #include "WorldInfo.h"
 #include "VotingArbiter.h"
 #include "ShotManager.h"
+#include "MessageBuffers.h"
 
 #include <list>
 class PendingChatMessages
@@ -98,8 +99,7 @@ extern void grantFlag(int playerIndex, FlagInfo &flag, bool checkPos = true);
 extern void sendPlayerMessage(GameKeeper::Player *playerData,
                               PlayerId dstPlayer,
                               const char *message);
-extern char *getDirectMessageBuffer();
-extern void  broadcastMessage(uint16_t code, int len, void *msg);
+
 extern void  sendTeamUpdate(int playerIndex = -1,
                             int teamIndex1 = -1,
                             int teamIndex2 = -1);
@@ -108,8 +108,14 @@ extern void  sendPlayerUpdate(GameKeeper::Player* player);
 extern void  sendDrop(FlagInfo &flag);
 extern void  sendIPUpdate(int targetPlayer = -1, int playerIndex = -1);
 extern void  sendPlayerInfo(void);
-extern void  directMessage(int playerIndex, uint16_t code,
-                           int len, void *msg);
+
+extern char *getDirectMessageBuffer();
+extern void  directMessage(int playerIndex, uint16_t code, int len, void *msg);
+extern void  broadcastMessage(uint16_t code, int len, void *msg);
+
+extern void sendPacket(int playerIndex, uint16_t code, MessageBuffer::Ptr message, bool release = true);
+extern void broadcastPacket(uint16_t code, MessageBuffer::Ptr message);
+
 extern int   getCurMaxPlayers();
 extern bool  areFoes(TeamColor team1, TeamColor team2);
 extern PingPacket getTeamCounts();

--- a/src/bzfs/bzfs.h
+++ b/src/bzfs/bzfs.h
@@ -109,10 +109,6 @@ extern void  sendDrop(FlagInfo &flag);
 extern void  sendIPUpdate(int targetPlayer = -1, int playerIndex = -1);
 extern void  sendPlayerInfo(void);
 
-extern char *getDirectMessageBuffer();
-extern void  directMessage(int playerIndex, uint16_t code, int len, void *msg);
-extern void  broadcastMessage(uint16_t code, int len, void *msg);
-
 extern void sendPacket(int playerIndex, uint16_t code, MessageBuffer::Ptr message, bool release = true);
 extern void broadcastPacket(uint16_t code, MessageBuffer::Ptr message);
 

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -3460,19 +3460,6 @@ BZF_API const char* bz_pluginBinPath(void)
 BZF_API bool bz_sendPlayCustomLocalSound ( int UNUSED(playerID), const char* UNUSED(soundName) )
 {
     return false;
-//   if (playerID == BZ_SERVER || !soundName)
-//     return false;
-//
-//   void *buf, *bufStart = getDirectMessageBuffer();
-//   buf = nboPackUShort(bufStart, LocalCustomSound);
-//   buf = nboPackUShort(buf, (unsigned short)strlen(soundName));
-//   buf = nboPackString(buf, soundName,strlen(soundName));
-//   if (playerID == BZ_ALLUSERS)
-//     broadcastMessage(MsgCustomSound, (char*)buf - (char*)bufStart, bufStart);
-//   else
-//     directMessage(playerID,MsgCustomSound, (char*)buf - (char*)bufStart, bufStart);
-//
-//   return true;
 }
 
 // custom pluginHandler

--- a/src/bzfs/commands.cxx
+++ b/src/bzfs/commands.cxx
@@ -51,7 +51,7 @@
 #include "Permissions.h"
 #include "RecordReplay.h"
 #include "bzfs.h"
-#include "PackVars.h"   // uses directMessage() from bzfs.h
+#include "PackVars.h"   // uses sendPacket() from bzfs.h
 
 
 #if defined(_WIN32)
@@ -1225,10 +1225,11 @@ bool GameOverCommand::operator() (const char     *,
         return true;
     }
 
-    void *buf, *bufStart = getDirectMessageBuffer();
-    buf = nboPackUByte(bufStart, t);
-    buf = nboPackUShort(buf, uint16_t(NoTeam));
-    broadcastMessage(MsgScoreOver, (char*)buf - (char*)bufStart, bufStart);
+    auto buf = GetMessageBuffer();
+    buf->packUByte(t);
+    buf->packUShort(uint16_t(NoTeam));
+    broadcastPacket(MsgScoreOver, buf);
+
     gameOver = true;
     if (clOptions->timeManualStart)
     {
@@ -1703,10 +1704,10 @@ bool FlagCommand::operator() (const char     *message,
                 GameKeeper::Player* fPlayer = GameKeeper::Player::getPlayerByIndex(fi->player);
                 if (fPlayer)
                 {
-                    void *bufStart = getDirectMessageBuffer();
-                    void *buf = nboPackUByte(bufStart, fi->player);
-                    buf = fi->pack(buf);
-                    broadcastMessage(MsgFlagDropped, (char*)buf - (char*)bufStart, bufStart);
+                    auto buf = GetMessageBuffer();
+                    buf->packUByte(fi->player);
+                    buf->legacyPack(fi->pack(buf->current_buffer()));
+                    broadcastPacket(MsgFlagDropped, buf);
                     fPlayer->grantFlag(-1);
                 }
             }

--- a/src/common/Flag.cxx
+++ b/src/common/Flag.cxx
@@ -350,16 +350,16 @@ FlagType::TypeMap& FlagType::getFlagMap()
 
 void* FlagInstance::pack(void* buf) const
 {
-    buf = type->pack(buf);
-    buf = nboPackUShort(buf, uint16_t(status));
-    buf = nboPackUShort(buf, uint16_t(endurance));
-    buf = nboPackUByte(buf, owner);
-    buf = nboPackVector(buf, position);
-    buf = nboPackVector(buf, launchPosition);
-    buf = nboPackVector(buf, landingPosition);
-    buf = nboPackFloat(buf, flightTime);
-    buf = nboPackFloat(buf, flightEnd);
-    buf = nboPackFloat(buf, initialVelocity);
+    buf = type->pack(buf);                          //  2
+    buf = nboPackUShort(buf, uint16_t(status));     //  4
+    buf = nboPackUShort(buf, uint16_t(endurance));  //  6
+    buf = nboPackUByte(buf, owner);                 //  7
+    buf = nboPackVector(buf, position);             //  19
+    buf = nboPackVector(buf, launchPosition);       //  31
+    buf = nboPackVector(buf, landingPosition);      //  43
+    buf = nboPackFloat(buf, flightTime);            //  47
+    buf = nboPackFloat(buf, flightEnd);             //  51
+    buf = nboPackFloat(buf, initialVelocity);       //  55
     return buf;
 }
 

--- a/src/common/ShotUpdate.cxx
+++ b/src/common/ShotUpdate.cxx
@@ -55,7 +55,7 @@ FiringInfo::FiringInfo()
     // do nothing -- must be prepared before use by unpack() or assignment
 }
 
-void           FiringInfo::pack(MessageBuffer::Ptr msg) const
+void* FiringInfo::pack(void* buf) const
 {
     buf = nboPackFloat(buf, timeSent);
     buf = nboPackUShort(buf, (uint16_t)localID);

--- a/src/common/ShotUpdate.cxx
+++ b/src/common/ShotUpdate.cxx
@@ -55,7 +55,7 @@ FiringInfo::FiringInfo()
     // do nothing -- must be prepared before use by unpack() or assignment
 }
 
-void*           FiringInfo::pack(void* buf) const
+void           FiringInfo::pack(MessageBuffer::Ptr msg) const
 {
     buf = nboPackFloat(buf, timeSent);
     buf = nboPackUShort(buf, (uint16_t)localID);


### PR DESCRIPTION
Instead of using a single outbound buffer, have the server use a rotating pool of buffers.
buffers are locked when got, and released when sending the message is completed.
this fixes issues where the API calls events while building up a network message and plug-ins then call functions that send messages, and thus blow out the in progress message buffer.
This will also be useful if/when threads are used on the server, multiple buffers can be built up at the same time.