### PR TITLE
refactor TimeKeeper to use std::chrono

### DIFF
--- a/include/CommandManager.h
+++ b/include/CommandManager.h
@@ -10,8 +10,9 @@
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef __COMMANDMANAGER_H__
-#define __COMMANDMANAGER_H__
+#pragma once
+#ifndef CommandManager_h__
+#define CommandManager_h__
 
 #include "common.h"
 
@@ -31,8 +32,7 @@ class CommandManager : public Singleton<CommandManager> {
 
 public:
 
-  CommandManager();
-  ~CommandManager();
+  CommandManager() = default;
 
   // type of function that implements command.  function should return
   // a string with the output of the command (or the empty string if
@@ -78,7 +78,7 @@ private:
 };
 
 
-#endif /* __COMMANDMANAGER_H__ */
+#endif /* CommandManager_h__ */
 
 // Local Variables: ***
 // mode: C++ ***

--- a/include/Singleton.h
+++ b/include/Singleton.h
@@ -65,48 +65,52 @@ protected:
   // protection from instantiating a non-singleton Singleton
   Singleton() {}
   Singleton(T* instancePointer) { _instance = instancePointer; }
-  Singleton(const Singleton &) {} // do not use
-  Singleton& operator=(const Singleton&) { return *this; } // do not use
-  ~Singleton() { _instance = 0; } // do not delete
+  Singleton(const Singleton &) = delete;
+  Singleton& operator=(const Singleton&) = delete;
+  ~Singleton() = delete;
 
-  static void destroy() {
-    if ( _instance != 0 ) {
-      delete(_instance);
-      _instance = 0;
-    }
-  }
+  static void destroy();
 
 public:
 
   /** returns a singleton
    */
-  inline static T& instance() {
-    if ( _instance == 0 ) {
-      _instance = new T;
-      // destroy the singleton when the application terminates
-#ifdef HAVE_ATEXIT
-      atexit(Singleton::destroy);
-#endif
-    }
-    return *Singleton::_instance;
-  }
+  static T& instance();
 
   /** returns a singleton pointer
    */
-  inline static T* pInstance() {
-    if (_instance == 0) {
-      _instance = new T;
-#ifdef HAVE_ATEXIT
-      atexit(Singleton::destroy);
-#endif
-    }
-    return Singleton::_instance;
-  }
+  static T* pInstance();
 
   /** returns a const singleton reference
    */
   inline static const T& constInstance() { return *instance(); }
 };
+
+template <typename T>
+T* Singleton<T>::_instance = nullptr;
+
+template <typename T>
+void Singleton<T>::destroy() {
+  delete _instance;
+  _instance = nullptr;
+}
+
+template <typename T>
+T& Singleton<T>::instance() {
+  return *pInstance();
+}
+
+template <typename T>
+T* Singleton<T>::pInstance() {
+  if (_instance == nullptr) {
+    _instance = new T;
+#ifdef HAVE_ATEXIT
+    atexit(Singleton::destroy);
+#endif
+  }
+  return Singleton::_instance;
+}
+
 
 #endif /* __SINGLETON_H__ */
 

--- a/include/TimeKeeper.h
+++ b/include/TimeKeeper.h
@@ -20,12 +20,14 @@
  * operator+=() allows a time in seconds to be added to a TimeKeeper.
  */
 
+#pragma once
 #ifndef	BZF_TIME_KEEPER_H
 #define	BZF_TIME_KEEPER_H
 
 #include "common.h"
 
 /* system interface headers */
+#include <chrono>
 #include <string>
 
 
@@ -37,53 +39,45 @@
  */
 class TimeKeeper {
 public:
-  TimeKeeper();
-  TimeKeeper(const TimeKeeper&);
-  ~TimeKeeper();
-  TimeKeeper&		operator=(const TimeKeeper&);
+  TimeKeeper() = default;
+  using Seconds_t = std::chrono::duration<double>;
 
+  explicit TimeKeeper(Seconds_t secs);
+
+  operator bool() const;
+  
   double		operator-(const TimeKeeper&) const;
   bool			operator<=(const TimeKeeper&) const;
   TimeKeeper&		operator+=(double);
   TimeKeeper&		operator+=(const TimeKeeper&);
 
-	// make a TimeKeeper with seconds = NULL act like unset
-	// Fixme: must this be defined here? didn't work for me outside the class
-	inline operator void*()
-	{
-		if (seconds > 0.0)
-			return this;
-		else
-			return NULL;
-	}
-
   /** returns how many seconds have elapsed since epoch, Jan 1, 1970 */
-  double       getSeconds(void) const;
+  double       getSeconds() const;
 
   /** returns a timekeeper representing the current time */
-  static const TimeKeeper&	getCurrent(void);
+  static const TimeKeeper&	getCurrent();
 
   /** returns a timekeeper representing the time of program execution */
-  static const TimeKeeper&	getStartTime(void);
+  static const TimeKeeper&	getStartTime();
 
   /** sets the time to the current time (recalculates) */
-  static void			setTick(void);
+  static void			setTick();
   /** returns a timekeeper that is updated periodically via setTick */
-  static const TimeKeeper&	getTick(void); // const
+  static const TimeKeeper&	getTick(); // const
 
   /** returns a timekeeper representing +Inf */
-  static const TimeKeeper&	getSunExplodeTime(void);
+  static const TimeKeeper&	getSunExplodeTime();
   /** returns a timekeeper representing -Inf */
-  static const TimeKeeper&	getSunGenesisTime(void);
+  static const TimeKeeper&	getSunGenesisTime();
   /** returns a timekeeper representing an unset timekeeper */
-  static const TimeKeeper&	getNullTime(void);
+  static const TimeKeeper&	getNullTime();
 
 
   /** returns the local time */
   static void localTime(int *year = NULL, int *month = NULL, int* day = NULL, int* hour = NULL, int* min = NULL, int* sec = NULL, bool* dst = NULL);
 
   /** returns a string of the local time */
-  static const char		*timestamp(void);
+  static const char		*timestamp();
 
   static void localTime( int &day);
 
@@ -93,7 +87,7 @@ public:
 
   /** converts a time difference into an array of integers
       representing days, hours, minutes, seconds */
-  static void			convertTime(double raw, long int convertedTimes[]);
+  static void			convertTime(Seconds_t raw, long int convertedTimes[]);
   /** prints an integer-array time difference in human-readable form */
   static const std::string	printTime(long int timeValue[]);
   /** prints an float time difference in human-readable form */
@@ -102,66 +96,42 @@ public:
   /** sleep for a given number of floating point seconds */
   static void			sleep(double secs); //const
 
+protected:
+  // not that we expect to subclass, but prefer separating methods from members
+  void now();
+  
 private:
-  double		seconds;
-  static TimeKeeper	currentTime;
-  static TimeKeeper	tickTime;
-  static TimeKeeper	sunExplodeTime;
-  static TimeKeeper	sunGenesisTime;
-  static TimeKeeper	nullTime;
-  static TimeKeeper	startTime;
+  std::chrono::time_point<std::chrono::steady_clock, Seconds_t> lastTime; // floating seconds
 };
 
 //
 // TimeKeeper
 //
 
-inline TimeKeeper::TimeKeeper() : seconds(0.0)
-{
-  // do nothing
-}
-
-inline TimeKeeper::TimeKeeper(const TimeKeeper& t) :
-  seconds(t.seconds)
-{
-  // do nothing
-}
-
-inline TimeKeeper::~TimeKeeper()
-{
-  // do nothing
-}
-
-inline TimeKeeper&	TimeKeeper::operator=(const TimeKeeper& t)
-{
-  seconds = t.seconds;
-  return *this;
-}
-
 inline double		TimeKeeper::operator-(const TimeKeeper& t) const
 {
-  return seconds - t.seconds;
+  return (lastTime - t.lastTime).count();
 }
 
 inline TimeKeeper&	TimeKeeper::operator+=(double dt)
 {
-  seconds += dt;
+  lastTime += Seconds_t(dt);
   return *this;
 }
 inline TimeKeeper&	TimeKeeper::operator+=(const TimeKeeper& t)
 {
-  seconds += t.seconds;
+  lastTime += t.lastTime.time_since_epoch();
   return *this;
 }
 
 inline bool		TimeKeeper::operator<=(const TimeKeeper& t) const
 {
-  return seconds <= t.seconds;
+  return lastTime <= t.lastTime;
 }
 
-inline double		TimeKeeper::getSeconds(void) const
+inline double		TimeKeeper::getSeconds() const
 {
-  return seconds;
+  return lastTime.time_since_epoch().count();
 }
 
 

--- a/package/win32/Makefile.am
+++ b/package/win32/Makefile.am
@@ -1,4 +1,7 @@
 SUBDIRS = nsis
 
+EXTRA_DIST =	\
+	README.win32.html
+
 MAINTAINERCLEANFILES = \
 	Makefile.in

--- a/src/bzfs/bzfs.cxx
+++ b/src/bzfs/bzfs.cxx
@@ -740,19 +740,19 @@ void startCountdown ( int delay, float limit, int playerID )
   // let everyone know what's going on
   long int timeArray[4];
   std::string matchBegins;
-  if (countdownDelay == 0)
+  if (countdownDelay == -1)
   {
     matchBegins = "Match begins now!";
   }
   else
   {
-    TimeKeeper::convertTime(countdownDelay, timeArray);
+    TimeKeeper::convertTime(TimeKeeper::Seconds_t(countdownDelay), timeArray);
     std::string countdowntime = TimeKeeper::printTime(timeArray);
     matchBegins = TextUtils::format("Match begins in about %s", countdowntime.c_str());
   }
   sendMessage(ServerPlayer, AllPlayers, matchBegins.c_str());
 
-  TimeKeeper::convertTime(clOptions->timeLimit, timeArray);
+  TimeKeeper::convertTime(TimeKeeper::Seconds_t(clOptions->timeLimit), timeArray);
   std::string timelimit = TimeKeeper::printTime(timeArray);
   matchBegins = TextUtils::format("Match duration is %s", timelimit.c_str());
   sendMessage(ServerPlayer, AllPlayers, matchBegins.c_str());

--- a/src/common/CommandManager.cxx
+++ b/src/common/CommandManager.cxx
@@ -24,18 +24,8 @@
 
 
 // initialize the singleton
-template <>
-CommandManager* Singleton<CommandManager>::_instance = (CommandManager*)0;
-
-CommandManager::CommandManager()
-{
-  // do nothing
-}
-
-CommandManager::~CommandManager()
-{
-  // do nothing
-}
+// template <>
+// CommandManager* Singleton<CommandManager>::_instance = (CommandManager*)0;
 
 void				CommandManager::add(const std::string& name,
 						    CommandFunction func,

--- a/src/common/TimeKeeper.cxx
+++ b/src/common/TimeKeeper.cxx
@@ -14,155 +14,84 @@
 #include "TimeKeeper.h"
 
 /* system implementation headers */
-#include <time.h>
-#include <string>
-#include <string.h>
-#ifdef HAVE_UNISTD_H
-#  include <unistd.h>
-#endif
-#ifdef __BEOS__
-#  include <OS.h>
-#endif
-#if !defined(_WIN32)
-#  include <sys/time.h>
-#  include <sys/types.h>
-static struct timeval	lastTime = { 0, 0 };
-#else /* !defined(_WIN32) */
-#  include <mmsystem.h>
-static unsigned long int	lastTime = 0;
-static LARGE_INTEGER	qpcLastTime;
-static LONGLONG		qpcFrequency = 0;
-static LONGLONG	 qpcLastCalibration;
-static DWORD	    timeLastCalibration;
-#endif /* !defined(_WIN32) */
+#include <thread>
+// #include <time.h>
+// #include <string>
+// #include <string.h>
+// #ifdef HAVE_UNISTD_H
+// #  include <unistd.h>
+// #endif
+// #ifdef __BEOS__
+// #  include <OS.h>
+// #endif
 
 /* common implementation headers */
 #include "TextUtils.h"
 #include "bzfio.h"
 
 
-TimeKeeper TimeKeeper::currentTime;
-TimeKeeper TimeKeeper::tickTime;
-TimeKeeper TimeKeeper::sunExplodeTime;
-TimeKeeper TimeKeeper::sunGenesisTime;
-TimeKeeper TimeKeeper::nullTime;
-TimeKeeper TimeKeeper::startTime = TimeKeeper::getCurrent();
+namespace {
+  TimeKeeper currentTime;
+  TimeKeeper startTime = TimeKeeper::getCurrent(); // initialize when we started
+  TimeKeeper tickTime;
 
-const TimeKeeper&	TimeKeeper::getCurrent(void)
+  TimeKeeper sunExplodeTime{TimeKeeper::Seconds_t::max()};
+  TimeKeeper sunGenesisTime{TimeKeeper::Seconds_t::min()};
+  TimeKeeper nullTime{TimeKeeper::Seconds_t::zero()};
+}
+
+TimeKeeper::TimeKeeper(Seconds_t secs)
+  : lastTime(secs)
 {
-  // if not first call then update current time, else use default initial time
-#if !defined(_WIN32)
-  if (lastTime.tv_sec != 0) {
-    struct timeval now;
-    gettimeofday(&now, NULL);
-    currentTime += double(now.tv_sec - lastTime.tv_sec) +
-		1.0e-6 * double(now.tv_usec - lastTime.tv_usec);
-    lastTime = now;
-  }
-  else {
-    gettimeofday(&lastTime, NULL);
-  }
-#else /* !defined(_WIN32) */
-  if (qpcFrequency != 0) {
+}
 
-    // main timer is qpc
-    LARGE_INTEGER now;
-    QueryPerformanceCounter(&now);
+TimeKeeper::operator bool() const
+{
+  return lastTime != nullTime.lastTime;
+}
 
-    LONGLONG diff     = now.QuadPart - qpcLastTime.QuadPart;
-    LONGLONG clkSpent = now.QuadPart - qpcLastCalibration;
+void TimeKeeper::now()
+{
+  lastTime = std::chrono::steady_clock::now();
+}
 
-    if (clkSpent > qpcFrequency) {
-      // Recalibrate Frequency
-      DWORD tgt	   = timeGetTime();
-      DWORD deltaTgt      = tgt - timeLastCalibration;
-      timeLastCalibration = tgt;
-      qpcLastCalibration  = now.QuadPart;
-      if (deltaTgt > 0) {
-	LONGLONG oldqpcfreq = qpcFrequency;
-	qpcFrequency	= (clkSpent * 1000) / deltaTgt;
-	if (qpcFrequency != oldqpcfreq)
-	  logDebugMessage(4,"Recalibrated QPC frequency.  Old: %f ; New: %f\n",
-		 (double)oldqpcfreq, (double)qpcFrequency);
-      }
-    }
-
-    currentTime += (double) diff / (double) qpcFrequency;
-    qpcLastTime = now;
-  } else if (lastTime != 0) {
-    unsigned long int now = (unsigned long int)timeGetTime();
-    unsigned long int diff;
-    if (now <= lastTime) {
-      // eh, how'd we go back in time?
-      diff = 0;
-    } else {
-      diff = now - lastTime;
-    }
-    currentTime += 1.0e-3 * (double)diff;
-    lastTime = now;
-  } else {
-    static bool sane = true;
-
-    // should only get into here once on app start
-    if (!sane) {
-      logDebugMessage(1,"Sanity check failure in TimeKeeper::getCurrent()\n");
-    }
-    sane = false;
-
-    LARGE_INTEGER freq;
-    if (QueryPerformanceFrequency(&freq)) {
-      QueryPerformanceCounter(&qpcLastTime);
-      qpcFrequency	= freq.QuadPart;
-      logDebugMessage(4,"Actual reported QPC Frequency: %f\n", (double)qpcFrequency);
-      qpcLastCalibration  = qpcLastTime.QuadPart;
-      timeLastCalibration = timeGetTime();
-    } else {
-      logDebugMessage(1,"QueryPerformanceFrequency failed with error %d\n", GetLastError());
-
-      // make sure we're at our best timer resolution possible
-      timeBeginPeriod(1);
-
-      lastTime = (unsigned long int)timeGetTime();
-    }
-  }
-#endif /* !defined(_WIN32) */
+const TimeKeeper&	TimeKeeper::getCurrent()
+{
+  currentTime.now();
   return currentTime;
 }
 
-const TimeKeeper&	TimeKeeper::getStartTime(void) // const
+const TimeKeeper&	TimeKeeper::getStartTime() // const
 {
   return startTime;
 }
 
-const TimeKeeper&	TimeKeeper::getTick(void) // const
+const TimeKeeper&	TimeKeeper::getTick() // const
 {
   return tickTime;
 }
 
-void			TimeKeeper::setTick(void)
+void			TimeKeeper::setTick()
 {
   tickTime = getCurrent();
 }
 
-const TimeKeeper& TimeKeeper::getSunExplodeTime(void)
+const TimeKeeper& TimeKeeper::getSunExplodeTime()
 {
-  sunExplodeTime.seconds = 10000.0 * 365 * 24 * 60 * 60;
   return sunExplodeTime;
 }
 
-const TimeKeeper& TimeKeeper::getSunGenesisTime(void)
+const TimeKeeper& TimeKeeper::getSunGenesisTime()
 {
-  sunGenesisTime.seconds = -10000.0 * 365 * 24 * 60 * 60;
   return sunGenesisTime;
 }
 
-const TimeKeeper& TimeKeeper::getNullTime(void)
+const TimeKeeper& TimeKeeper::getNullTime()
 {
-  nullTime.seconds = 0;
   return nullTime;
 }
 
-const char *TimeKeeper::timestamp(void) // const
+const char *TimeKeeper::timestamp() // const
 {
   static char buffer[256]; // static, so that it doesn't vanish
   time_t tnow = time(0);
@@ -180,25 +109,25 @@ const char *TimeKeeper::timestamp(void) // const
 
 void TimeKeeper::localTime(int *year, int *month, int* day, int* hour, int* min, int* sec, bool* dst) // const
 {
-	time_t tnow = time(0);
-	struct tm *now = localtime(&tnow);
-	now->tm_year += 1900;
-	++now->tm_mon;
+  time_t tnow = time(0);
+  struct tm *now = localtime(&tnow);
+  now->tm_year += 1900;
+  ++now->tm_mon;
 
-	if ( year )
-		*year = now->tm_year;
-	if ( month )
-		*month = now->tm_mon;
-	if ( day )
-		*day = now->tm_mday;
-	if ( hour )
-		*hour = now->tm_hour;
-	if ( min )
-		*min = now->tm_min;
-	if ( sec )
-		*sec = now->tm_sec;
-	if ( dst )
-		*dst = now->tm_isdst != 0;
+  if ( year )
+    *year = now->tm_year;
+  if ( month )
+    *month = now->tm_mon;
+  if ( day )
+    *day = now->tm_mday;
+  if ( hour )
+    *hour = now->tm_hour;
+  if ( min )
+    *min = now->tm_min;
+  if ( sec )
+    *sec = now->tm_sec;
+  if ( dst )
+    *dst = now->tm_isdst != 0;
 }
 
 
@@ -222,24 +151,25 @@ void TimeKeeper::UTCTime(int *year, int *month, int* day, int* wday,
 
 // function for converting a float time (e.g. difference of two TimeKeepers)
 // into an array of ints
-void TimeKeeper::convertTime(double raw, long int convertedTimes[])
+void TimeKeeper::convertTime(Seconds_t raw, long int convertedTimes[])
 {
-  long int day, hour, min, sec, remainder;
-  static const int secondsInDay = 86400;
+  // std::chrono::days is C++-20
+  auto days = std::chrono::duration_cast<std::chrono::duration<int32_t, std::ratio<86400>>>(raw);
+  raw -= days;
 
-  sec = (long int)raw;
-  day = sec / secondsInDay;
-  remainder = sec - (day * secondsInDay);
-  hour = remainder / 3600;
-  remainder = sec - ((hour * 3600) + (day * secondsInDay));
-  min = remainder / 60;
-  remainder = sec - ((hour * 3600) + (day * secondsInDay) + (min * 60));
-  sec = remainder;
+  auto hours = std::chrono::duration_cast<std::chrono::hours>(raw);
+  raw -= hours;
 
-  convertedTimes[0] = day;
-  convertedTimes[1] = hour;
-  convertedTimes[2] = min;
-  convertedTimes[3] = sec;
+  auto mins = std::chrono::duration_cast<std::chrono::minutes>(raw);
+  raw -= mins;
+
+  auto secs = std::chrono::duration_cast<std::chrono::seconds>(raw);
+  raw -= secs;
+  
+  convertedTimes[0] = days.count();
+  convertedTimes[1] = hours.count();
+  convertedTimes[2] = mins.count();
+  convertedTimes[3] = secs.count();
 
   return;
 }
@@ -284,48 +214,15 @@ const std::string TimeKeeper::printTime(long int timeValue[])
 const std::string TimeKeeper::printTime(double diff)
 {
   long int temp[4];
-  convertTime(diff, temp);
+  convertTime(Seconds_t(diff), temp);
   return printTime(temp);
 }
 
 
 void TimeKeeper::sleep(double seconds)
 {
-  if (seconds <= 0.0) {
-    return;
-  }
-
-#ifdef HAVE_USLEEP
-  usleep((unsigned int)(1.0e6 * seconds));
-  return;
-#endif
-#if defined(HAVE_SLEEP) && !defined(__APPLE__)
-  // equivalent to _sleep() on win32 (not sleep(3))
-  Sleep((DWORD)(seconds * 1000.0));
-  return;
-#endif
-#ifdef HAVE_SNOOZE
-  snooze((bigtime_t)(1.0e6 * seconds));
-  return;
-#endif
-#ifdef HAVE_SELECT
-  struct timeval tv;
-  tv.tv_sec = (long)seconds;
-  tv.tv_usec = (long)(1.0e6 * (seconds - tv.tv_sec));
-  select(0, NULL, NULL, NULL, &tv);
-  return;
-#endif
-#ifdef HAVE_WAITFORSINGLEOBJECT
-  HANDLE dummyEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
-  WaitForSingleObject(dummyEvent, (DWORD)(1000.0 * seconds));
-  CloseHandle(dummyEvent);
-  return;
-#endif
-
-  // fall-back case is fugly manual timekeeping
-  TimeKeeper now = TimeKeeper::getCurrent();
-  while ((TimeKeeper::getCurrent() - now) < seconds) {
-    continue;
+  if (seconds > 0.0) {
+    std::this_thread::sleep_for(Seconds_t(seconds));
   }
   return;
 }


### PR DESCRIPTION
This change updates TimeKeeper to use the std::chrono types present since C++-11. It should (by definition) be portable and eliminate platform-specific code for time keeping.

(I should have pushed my rebase before making this change, but I don't know how to fix it now. These 3 files are the sum total of this change)