### PR TITLE
Use AC_CHECK_HEADER and AC_SEARCH_LIBS for finding GL/GLU/GLEW and don't depend on pkg-config

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ BZFlag 2.4.15
 
 * Revert a80ab87 (truncation warning fix) as that generated broken replay file
     headers. Detect and work around that bad header. - Scott Wichser
+* Use pkg-config, if available, to detect ncurses
+    - Scott Wichser, Joshua Bodine, Alfredo Tupone
 
 
 BZFlag 2.4.14  "Hello Motto" (2018-05-02)

--- a/autogen.sh
+++ b/autogen.sh
@@ -75,7 +75,7 @@
 
 # set to minimum acceptible version of autoconf
 if [ "x$AUTOCONF_VERSION" = "x" ] ; then
-    AUTOCONF_VERSION=2.58
+    AUTOCONF_VERSION=2.69
 fi
 # set to minimum acceptible version of automake
 if [ "x$AUTOMAKE_VERSION" = "x" ] ; then

--- a/autogen.sh
+++ b/autogen.sh
@@ -75,7 +75,7 @@
 
 # set to minimum acceptible version of autoconf
 if [ "x$AUTOCONF_VERSION" = "x" ] ; then
-    AUTOCONF_VERSION=2.69
+    AUTOCONF_VERSION=2.68
 fi
 # set to minimum acceptible version of automake
 if [ "x$AUTOMAKE_VERSION" = "x" ] ; then

--- a/configure.ac
+++ b/configure.ac
@@ -125,11 +125,7 @@ dnl ***********************
 BZ_CONFIGURE_STAGE([arguments], [1 of 9])
 
 # provide a with-curses option, test for curses
-PKG_CHECK_MODULES(ncurses, ncurses,
-  [CURSES_LIB="$ncurses_LIBS"]
-  AC_DEFINE(HAVE_NCURSES_H, , [Use the header file ncurses.h]),
-  AC_MSG_ERROR([Could not find ncurses]))
-AC_SUBST(CURSES_LIB)
+MP_WITH_CURSES
 
 # check for SDL option (enabled by default now)
 AC_ARG_WITH(SDL, AS_HELP_STRING([--without-SDL | --with-SDL={1,2}],[Do not use Simple DirectMedia Layer or force using a specific version (by default tries 2, then 1, then resorts to native platform code if available]), sdl_version="$withval", sdl_version="detect")

--- a/configure.ac
+++ b/configure.ac
@@ -1174,13 +1174,12 @@ else
 fi
 
 if test "x$enable_bzadmin" = "xno"; then
-    if test "x$CURSES_LIB" = x; then
-	build_bzadmin="no bzadmin binary! (need Curses)"
-    else
-	build_bzadmin="no bzadmin binary!"
-    fi
+    build_bzadmin="no bzadmin binary!"
 else
     build_bzadmin="yes"
+    if test "x$CURSES_LIB" != x; then
+	build_bzadmin="$build_bzadmin (with curses)"
+    fi
 fi
 
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ dnl
 
 dnl Minimum version of autoconf required.  Should coincide with the
 dnl setting in the autogen.sh script.
-AC_PREREQ([2.58])
+AC_PREREQ([2.69])
 
 AC_INIT([BZFlag],[2.4.15],[http://BZFlag.org/],[bzflag])
 AC_CONFIG_SRCDIR(src/bzflag/bzflag.cxx)
@@ -539,8 +539,8 @@ AC_CHECK_TYPES([std::shared_ptr<int>],
 		[[#include <tr1/memory>]])],
 	[#include <memory>])
 
-ac_cv_search_glBegin=no
-ac_func_search_save_LIBS=$LIBS
+have_gl=yes
+savedLIBS=$LIBS
 
 case $host_os in
     solaris*)
@@ -559,6 +559,9 @@ case $host_os in
 	GLIBS=" -lmedia -lgame $GLIBS"
 	LIBS="-lbe"
 	;;
+    darwin*)
+        GLIBS="-framework OpenGL $GLIBS"
+        ;;
     *)
 	;;
 esac
@@ -588,28 +591,27 @@ case $host_os in
 	;;
 esac
 
-AC_MSG_CHECKING([for gl.h])
-LIBS="-framework OpenGL $GLIBS $ac_func_search_save_LIBS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <OpenGL/gl.h>]],
-	       [[glBegin(GL_POINTS)]])],
-		[ac_cv_search_glBegin="-framework OpenGL"],[])
-for ac_lib in opengl32 GL GL2; do
-    LIBS="-l$ac_lib $GLIBS $ac_func_search_save_LIBS"
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <GL/gl.h>]],
-				    [[glBegin(GL_POINTS)]])],
-		   [ac_cv_search_glBegin="-l$ac_lib"
-		    break],[])
-done
-if test "$ac_cv_search_glBegin" != no; then
-    GLIBS="$ac_cv_search_glBegin $GLIBS"
+case $host_os in
+    darwin*)
+        AC_CHECK_HEADER([OpenGL/gl.h], AC_SEARCH_LIBS(glBegin, [], [test $ac_cv_search_glBegin = "none required" || GLIBS="$ac_cv_search_glBegin $GLIBS"], [have_gl=no]), [have_gl=no ; ac_cv_search_glBegin=no], $GLIBS)
+        AC_CHECK_HEADER([OpenGL/glu.h], AC_SEARCH_LIBS(gluScaleImage, [], [test $ac_cv_search_gluScaleImage = "none required" || GLIBS="$ac_cv_search_gluScaleImage $GLIBS"], [have_gl=no]), [have_gl=no ; ac_cv_search_gluScaleImage=no], $GLIBS)
+        AC_CHECK_HEADER([OpenGL/glew.h], AC_SEARCH_LIBS(glewInit, [GLEW], [test $ac_cv_search_glewInit = "none required" || GLIBS="$ac_cv_search_glewInit $GLIBS"], [have_gl=no]), [have_gl=no ; ac_cv_search_glewInit=no], $GLIBS)
+
+        ;;
+    *)
+        AC_CHECK_HEADER([GL/gl.h], AC_SEARCH_LIBS(glBegin, [opengl32 GL GL2], [test $ac_cv_search_glBegin = "none required" || GLIBS="$ac_cv_search_glBegin $GLIBS"], [have_gl=no]), [have_gl=no ; ac_cv_search_glBegin=no])
+        AC_CHECK_HEADER([GL/glu.h], AC_SEARCH_LIBS(gluScaleImage, [glu32 GL GLU], [test $ac_cv_search_gluScaleImage = "none required" || GLIBS="$ac_cv_search_gluScaleImage $GLIBS"], [have_gl=no]), [have_gl=no ; ac_cv_search_gluScaleImage=no])
+        AC_CHECK_HEADER([GL/glew.h], AC_SEARCH_LIBS(glewInit, [GLEW], [test $ac_cv_search_glewInit = "none required" || GLIBS="$ac_cv_search_glewInit $GLIBS"], [have_gl=no]), [have_gl=no ; ac_cv_search_glewInit=no])
+        ;;
+esac
+
+if test "$have_gl" != no; then
     if test "$ac_cv_search_glBegin" = -lGL2; then
 	AC_DEFINE(BEOS_USE_GL2, 1, [Use new GL Kit for BeOS])
     fi
 fi
-have_gl=yes
-PKG_CHECK_MODULES([GLEW], glew, , [have_gl=no])
 
-LIBS=$ac_func_search_save_LIBS
+LIBS=$savedLIBS
 AC_SUBST(GLIBS)
 
 # try out pthreads if it's enabled, disable it if we don't have it
@@ -1134,7 +1136,19 @@ dnl **********************
 
 if test "x$enable_client" = "xno"; then
     if test "x$have_gl" = "xno" ; then
-	build_bzflag="no bzflag client binary! (need OpenGL)"
+	build_bzflag="no bzflag client binary!"
+
+        if test "x$ac_cv_search_glBegin" = xno ; then
+            build_bzflag="$build_bzflag (missing OpenGL)"
+        else
+            if test "x$ac_cv_search_gluScaleImage" = xno ; then
+                build_bzflag="$build_bzflag (missing GLU)"
+            fi
+
+            if test "x$ac_cv_search_glewInit" = xno ; then
+                build_bzflag="$build_bzflag (missing GLEW)"
+            fi
+        fi
     else
 	build_bzflag="no bzflag client binary!"
     fi
@@ -1204,6 +1218,7 @@ AC_MSG_RESULT([CPPFLAGS      = ${CPPFLAGS}])
 AC_MSG_RESULT([CONF_CPPFLAGS = ${CONF_CPPFLAGS}])
 AC_MSG_RESULT([LDFLAGS       = ${LDFLAGS}])
 AC_MSG_RESULT([LIBS          = ${LIBS}])
+AC_MSG_RESULT([GLIBS         = ${GLIBS}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([BZFlag client .....: $build_bzflag])
 AC_MSG_RESULT([BZFlag server .....: $build_bzfs])

--- a/configure.ac
+++ b/configure.ac
@@ -593,9 +593,9 @@ esac
 
 case $host_os in
     darwin*)
-        AC_CHECK_HEADER([OpenGL/gl.h], AC_SEARCH_LIBS(glBegin, [], [test $ac_cv_search_glBegin = "none required" || GLIBS="$ac_cv_search_glBegin $GLIBS"], [have_gl=no]), [have_gl=no ; ac_cv_search_glBegin=no], $GLIBS)
-        AC_CHECK_HEADER([OpenGL/glu.h], AC_SEARCH_LIBS(gluScaleImage, [], [test $ac_cv_search_gluScaleImage = "none required" || GLIBS="$ac_cv_search_gluScaleImage $GLIBS"], [have_gl=no]), [have_gl=no ; ac_cv_search_gluScaleImage=no], $GLIBS)
-        AC_CHECK_HEADER([OpenGL/glew.h], AC_SEARCH_LIBS(glewInit, [GLEW], [test $ac_cv_search_glewInit = "none required" || GLIBS="$ac_cv_search_glewInit $GLIBS"], [have_gl=no]), [have_gl=no ; ac_cv_search_glewInit=no], $GLIBS)
+        AC_CHECK_HEADER([OpenGL/gl.h], AC_SEARCH_LIBS(glBegin, [], [test $ac_cv_search_glBegin = "none required" || GLIBS="$ac_cv_search_glBegin $GLIBS"], [have_gl=no], $GLIBS), [have_gl=no ; ac_cv_search_glBegin=no])
+        AC_CHECK_HEADER([OpenGL/glu.h], AC_SEARCH_LIBS(gluScaleImage, [], [test $ac_cv_search_gluScaleImage = "none required" || GLIBS="$ac_cv_search_gluScaleImage $GLIBS"], [have_gl=no], $GLIBS), [have_gl=no ; ac_cv_search_gluScaleImage=no])
+        AC_CHECK_HEADER([OpenGL/glew.h], AC_SEARCH_LIBS(glewInit, [GLEW], [test $ac_cv_search_glewInit = "none required" || GLIBS="$ac_cv_search_glewInit $GLIBS"], [have_gl=no], $GLIBS), [have_gl=no ; ac_cv_search_glewInit=no])
 
         ;;
     *)

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ dnl
 
 dnl Minimum version of autoconf required.  Should coincide with the
 dnl setting in the autogen.sh script.
-AC_PREREQ([2.69])
+AC_PREREQ([2.68])
 
 AC_INIT([BZFlag],[2.4.15],[http://BZFlag.org/],[bzflag])
 AC_CONFIG_SRCDIR(src/bzflag/bzflag.cxx)

--- a/configure.ac
+++ b/configure.ac
@@ -593,9 +593,9 @@ esac
 
 case $host_os in
     darwin*)
-        AC_CHECK_HEADER([OpenGL/gl.h], AC_SEARCH_LIBS(glBegin, [], [test $ac_cv_search_glBegin = "none required" || GLIBS="$ac_cv_search_glBegin $GLIBS"], [have_gl=no], $GLIBS), [have_gl=no ; ac_cv_search_glBegin=no])
-        AC_CHECK_HEADER([OpenGL/glu.h], AC_SEARCH_LIBS(gluScaleImage, [], [test $ac_cv_search_gluScaleImage = "none required" || GLIBS="$ac_cv_search_gluScaleImage $GLIBS"], [have_gl=no], $GLIBS), [have_gl=no ; ac_cv_search_gluScaleImage=no])
-        AC_CHECK_HEADER([OpenGL/glew.h], AC_SEARCH_LIBS(glewInit, [GLEW], [test $ac_cv_search_glewInit = "none required" || GLIBS="$ac_cv_search_glewInit $GLIBS"], [have_gl=no], $GLIBS), [have_gl=no ; ac_cv_search_glewInit=no])
+        AC_CHECK_HEADER([OpenGL/gl.h], [ac_cv_search_glBegin="none required"], [have_gl=no ; ac_cv_search_glBegin=no])
+        AC_CHECK_HEADER([OpenGL/glu.h], [ac_cv_search_gluScaleImage="none required"], [have_gl=no ; ac_cv_search_gluScaleImage=no])
+        AC_CHECK_HEADER([GL/glew.h], AC_SEARCH_LIBS(glewInit, [GLEW], [test $ac_cv_search_glewInit = "none required" || GLIBS="$ac_cv_search_glewInit $GLIBS"], [have_gl=no], $GLIBS), [have_gl=no ; ac_cv_search_glewInit=no])
 
         ;;
     *)

--- a/m4/curses.m4
+++ b/m4/curses.m4
@@ -1,0 +1,66 @@
+# This macro tries to find curses, and defines HAVE_CURSES_H or HAVE_NCURSES_H
+# if any of those headers are found. It also defines CURSES_LIB.
+AC_DEFUN([MP_WITH_CURSES],
+  [AC_ARG_WITH(xcurses, [  --with-xcurses          Force the use of XCurses over ncurses],,)
+AC_ARG_WITH(curses, [  --with-curses           Force the use of curses over ncurses],,)
+    mp_save_LIBS="$LIBS"
+   CURSES_LIB=""
+   if test "$with_curses" != yes -a "$with_xcurses" != yes
+   then
+     AC_CACHE_CHECK([for working ncurses], mp_cv_ncurses,
+       [LIBS="$LIBS -lncurses"
+	AC_LINK_IFELSE([
+	AC_LANG_PROGRAM([[#include <ncurses.h>
+	]], [[chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr();
+	]])], [mp_cv_ncurses=yes], [mp_cv_ncurses=no])])
+     if test "$mp_cv_ncurses" = yes
+     then
+       AC_DEFINE(HAVE_NCURSES_H, , [Use the header file ncurses.h])
+       CURSES_LIB="-lncurses"
+     fi
+   fi
+   if test ! "$CURSES_LIB" -a "$with_xcurses" != yes
+   then
+     AC_CACHE_CHECK([for working curses], mp_cv_curses,
+       [LIBS="$mp_save_LIBS -lcurses"
+	AC_LINK_IFELSE([
+	AC_LANG_PROGRAM([[#include <curses.h>
+	]], [[chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr();
+	]])], [mp_cv_curses=yes], [mp_cv_curses=no])])
+     if test "$mp_cv_curses" = yes
+     then
+       AC_DEFINE(HAVE_CURSES_H, , [Use the header file curses.h])
+       CURSES_LIB="-lcurses"
+     fi
+   fi
+   if test ! "$CURSES_LIB" -a "$with_xcurses" != yes
+   then
+     AC_CACHE_CHECK([for working PDcurses], mp_cv_pdcurses,
+       [LIBS="$mp_save_LIBS -lpdcurses"
+	AC_LINK_IFELSE([
+	AC_LANG_PROGRAM([[#include <curses.h>
+	]], [[chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr();
+	]])], [mp_cv_pdcurses=yes], [mp_cv_pdcurses=no])])
+     if test "$mp_cv_pdcurses" = yes
+     then
+       AC_DEFINE(HAVE_CURSES_H, , [Use the header file curses.h])
+       CURSES_LIB="-lpdcurses"
+     fi
+   fi
+   if test ! "$CURSES_LIB" -a "$with_curses" != yes
+   then
+     xcurses_deplibs="-L$x_libraries -lXaw -lXmu -lXt -lX11 -lSM -lICE -lXext"
+     AC_CACHE_CHECK([for working XCurses], mp_cv_xcurses,
+       [LIBS="$mp_save_LIBS -lXCurses $xcurses_deplibs"
+	AC_LINK_IFELSE([
+	AC_LANG_PROGRAM([[#include <xcurses.h>
+	]], [[chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr();
+	]])], [mp_cv_xcurses=yes], [mp_cv_xcurses=no])])
+     if test "$mp_cv_xcurses" = yes
+     then
+       AC_DEFINE(HAVE_XCURSES_H, , [Use the header file xcurses.h])
+       CURSES_LIB="-lXCurses $xcurses_deplibs"
+     fi
+   fi
+   LIBS="$mp_save_LIBS"
+])dnl

--- a/m4/curses.m4
+++ b/m4/curses.m4
@@ -1,66 +1,30 @@
 # This macro tries to find curses, and defines HAVE_CURSES_H or HAVE_NCURSES_H
 # if any of those headers are found. It also defines CURSES_LIB.
-AC_DEFUN([MP_WITH_CURSES],
-  [AC_ARG_WITH(xcurses, [  --with-xcurses          Force the use of XCurses over ncurses],,)
-AC_ARG_WITH(curses, [  --with-curses           Force the use of curses over ncurses],,)
+AC_DEFUN([MP_WITH_CURSES], [
     mp_save_LIBS="$LIBS"
-   CURSES_LIB=""
-   if test "$with_curses" != yes -a "$with_xcurses" != yes
-   then
-     AC_CACHE_CHECK([for working ncurses], mp_cv_ncurses,
-       [LIBS="$LIBS -lncurses"
-	AC_LINK_IFELSE([
-	AC_LANG_PROGRAM([[#include <ncurses.h>
-	]], [[chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr();
-	]])], [mp_cv_ncurses=yes], [mp_cv_ncurses=no])])
-     if test "$mp_cv_ncurses" = yes
-     then
-       AC_DEFINE(HAVE_NCURSES_H, , [Use the header file ncurses.h])
-       CURSES_LIB="-lncurses"
-     fi
-   fi
-   if test ! "$CURSES_LIB" -a "$with_xcurses" != yes
-   then
-     AC_CACHE_CHECK([for working curses], mp_cv_curses,
-       [LIBS="$mp_save_LIBS -lcurses"
-	AC_LINK_IFELSE([
-	AC_LANG_PROGRAM([[#include <curses.h>
-	]], [[chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr();
-	]])], [mp_cv_curses=yes], [mp_cv_curses=no])])
-     if test "$mp_cv_curses" = yes
-     then
-       AC_DEFINE(HAVE_CURSES_H, , [Use the header file curses.h])
-       CURSES_LIB="-lcurses"
-     fi
-   fi
-   if test ! "$CURSES_LIB" -a "$with_xcurses" != yes
-   then
-     AC_CACHE_CHECK([for working PDcurses], mp_cv_pdcurses,
-       [LIBS="$mp_save_LIBS -lpdcurses"
-	AC_LINK_IFELSE([
-	AC_LANG_PROGRAM([[#include <curses.h>
-	]], [[chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr();
-	]])], [mp_cv_pdcurses=yes], [mp_cv_pdcurses=no])])
-     if test "$mp_cv_pdcurses" = yes
-     then
-       AC_DEFINE(HAVE_CURSES_H, , [Use the header file curses.h])
-       CURSES_LIB="-lpdcurses"
-     fi
-   fi
-   if test ! "$CURSES_LIB" -a "$with_curses" != yes
-   then
-     xcurses_deplibs="-L$x_libraries -lXaw -lXmu -lXt -lX11 -lSM -lICE -lXext"
-     AC_CACHE_CHECK([for working XCurses], mp_cv_xcurses,
-       [LIBS="$mp_save_LIBS -lXCurses $xcurses_deplibs"
-	AC_LINK_IFELSE([
-	AC_LANG_PROGRAM([[#include <xcurses.h>
-	]], [[chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr();
-	]])], [mp_cv_xcurses=yes], [mp_cv_xcurses=no])])
-     if test "$mp_cv_xcurses" = yes
-     then
-       AC_DEFINE(HAVE_XCURSES_H, , [Use the header file xcurses.h])
-       CURSES_LIB="-lXCurses $xcurses_deplibs"
-     fi
-   fi
-   LIBS="$mp_save_LIBS"
+    CURSES_LIB=""
+
+    ifdef([PKG_CHECK_MODULES], [
+        PKG_CHECK_MODULES([ncurses], [ncurses],
+        [CURSES_LIB="$ncurses_LIBS"]
+        AC_DEFINE(HAVE_NCURSES_H, , [Use the header file ncurses.h])
+        AC_SUBST(CURSES_LIB),
+        [_CHECK_CURSES])
+    ],
+    [_CHECK_CURSES])
+    LIBS="$mp_save_LIBS"
+])dnl
+
+AC_DEFUN([_CHECK_CURSES], [
+    AC_CACHE_CHECK([for working ncurses], mp_cv_ncurses,
+        [LIBS="$LIBS -lncurses"
+        AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([[#include <ncurses.h>
+        ]], [[chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr();
+        ]])], [mp_cv_ncurses=yes], [mp_cv_ncurses=no])])
+        if test "$mp_cv_ncurses" = yes ; then
+            AC_DEFINE(HAVE_NCURSES_H, , [Use the header file ncurses.h])
+            CURSES_LIB="-lncurses"
+            AC_SUBST(CURSES_LIB)
+        fi
 ])dnl


### PR DESCRIPTION
I replaced some of our AC_LINK_IFELSE macros with AC_CHECK_HEADER and AC_SEARCH_LIBS.  I currently special-cased macOS to look at the OpenGL/ include directory instead of GL/, but perhaps that could be simplified by using AC_CHECK_HEADERS instead of AC_CHECK_HEADER.  I can't test on mac to know if it even works in the current state.  I didn't want to depend on pkg-config which isn't included on a basic Debian install nor needed for a server-only build and without it autoconf would error out. This also reverts a change that made a curses library required even if you didn't care about bzadmin, going back to the old method where it would just build bzadmin without the curses UI.

I did also bump the minimum autoconf version to 2.69 (which is the latest version of autoconf, from April 2012).  I'm using a feature first mentioned in the documentation of autoconf 2.65 where AC_SEARCH_LIBS defines a ac_cv_search\__function_ variable, so we should be able to drop back to that if 2.69 is a problem.

This also shows more helpful information in the summary about what dependency is missing (GL, GLU, and/or GLEW).  It will still checks for game client dependencies and shows which are missing even if --disable-client is passed, but I didn't want to go crazy with cleanup/refactoring for this.

I have tested this on Debian Stretch (both a Gnome install and a minimal install), Debian Jessie, Ubuntu 14.04 Desktop, CentOS 7, and Fedora 24.  I did test it on Ubuntu 12.04 Server with the required autoconf version dropped back to 2.68, and it worked, but 12.04 hasn't been supported for over a year.  I'm hoping someone can test a *nix style build on macOS to make sure it works there.