### PR TITLE
Basic detection of MSVC version

### DIFF
--- a/MSVC/build/config.h
+++ b/MSVC/build/config.h
@@ -71,19 +71,36 @@
 // define our OS
 
 #ifndef BZ_BUILD_OS
+#ifndef BZ_MSVC_VER
+#if (_MSC_VER >= 1400 && _MSC_VER < 1500)
+#define BZ_MSVC_VER "VC8"
+#elif (_MSC_VER >= 1500 && _MSC_VER < 1600)
+#define BZ_MSVC_VER "VC9"
+#elif (_MSC_VER >= 1600 && _MSC_VER < 1700)
+#define BZ_MSVC_VER "VC10"
+#elif (_MSC_VER >= 1700 && _MSC_VER < 1800)
+#define BZ_MSVC_VER "VC11"
+#elif (_MSC_VER >= 1800 && _MSC_VER < 1900)
+#define BZ_MSVC_VER "VC12"
+#elif (_MSC_VER >= 1900 && _MSC_VER <= 1915)
+#define BZ_MSVC_VER "VC14"
+#else
+#error MSVC version out of range. Please update MSVC/build/config.h.
+#endif
+#endif // BZ_MSVC_VER
 #ifdef _DEBUG
 #define DEBUG
 #define DEBUG_RENDERING
 #ifdef _M_X64
-#define BZ_BUILD_OS         "Win64VC14Dbg"
+#define BZ_BUILD_OS         "Win64" BZ_MSVC_VER "Dbg"
 #else
-#define BZ_BUILD_OS         "Win32VC14Dbg"
+#define BZ_BUILD_OS         "Win32" BZ_MSVC_VER "Dbg"
 #endif
 #else
 #ifdef _M_X64
-#define BZ_BUILD_OS         "Win64VC14"
+#define BZ_BUILD_OS         "Win64" BZ_MSVC_VER
 #else
-#define BZ_BUILD_OS         "Win32VC14"
+#define BZ_BUILD_OS         "Win32" BZ_MSVC_VER
 #endif
 #endif //_DEBUG
 #endif //BZ_BUILD_OS


### PR DESCRIPTION
Currently, the MSVC version is hard-coded into the BZ_BUILD_OS string literal in MSVC/build/config.h. While historically we have not updated to newer major versions of Visual Studio very often, at times we have missed updating this string after doing so and we shipped binaries (even several versions in a row, IIRC) with the incorrect version in the build string.

Ideally, the MSVC version would be detected automatically by our code. There are several macros provided by the compiler, the closest of which seems to be _MSC_VER, which is an integer indicating the major and minor version numbers. It looks like if we could divide this by 100, subtract 5, and stringify it, we would have what we want. However, it does not appear possible to do all of this in the preprocessor, so the solution would be more invasive.

This logic detects the MSVC version based on predefined ranges of _MSC_VER all the way back to VC8 (which appears to be the very first version we used) for historical reasons, and throws an error if the value is out-of-range so we don't inadvertently miss this step when we update to new major versions of Visual Studio. This is based on information obtained from https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering