### PR TITLE
Make radar size and console height be controlled by BZDB variables as discussed on IRC

### DIFF
--- a/include/SceneRenderer.h
+++ b/include/SceneRenderer.h
@@ -192,6 +192,8 @@ private:
     SceneRenderer(const SceneRenderer&);
     SceneRenderer&    operator=(const SceneRenderer&);
 
+    static void bzdbCallback(const std::string& name, void *);
+
     void      setupBackgroundMaterials();
 
     void      getLights();

--- a/src/bzflag/GUIOptionsMenu.cxx
+++ b/src/bzflag/GUIOptionsMenu.cxx
@@ -529,13 +529,13 @@ void            GUIOptionsMenu::callback(HUDuiControl* w, const void* data)
 
     case 'R':
     {
-        sceneRenderer->setRadarSize(list->getIndex());
+        BZDB.setInt("radarsize", list->getIndex());
         break;
     }
 
     case 'a':
     {
-        sceneRenderer->setPanelHeight(list->getIndex());
+        BZDB.setInt("panelheight", list->getIndex());
         break;
     }
 

--- a/src/bzflag/SceneRenderer.cxx
+++ b/src/bzflag/SceneRenderer.cxx
@@ -323,9 +323,9 @@ void SceneRenderer::setRebuildTanks()
 
 void SceneRenderer::bzdbCallback(const std::string& name, void *)
 {
-    if(name == "radarsize")
+    if (name == "radarsize")
         RENDERER.setRadarSize(BZDB.evalInt("radarsize"));
-    else if(name == "panelheight")
+    else if (name == "panelheight")
         RENDERER.setPanelHeight(BZDB.evalInt("panelheight"));
 }
 

--- a/src/bzflag/SceneRenderer.cxx
+++ b/src/bzflag/SceneRenderer.cxx
@@ -112,6 +112,10 @@ SceneRenderer::SceneRenderer() :
     // init the track mark manager
     TrackMarks::init();
 
+    // add callbacks for radar size and panel height
+    BZDB.addCallback("radarsize", bzdbCallback, NULL);
+    BZDB.addCallback("panelheight", bzdbCallback, NULL);
+
     return;
 }
 
@@ -314,6 +318,15 @@ void SceneRenderer::setDepthComplexity(bool on)
 void SceneRenderer::setRebuildTanks()
 {
     rebuildTanks = true;
+}
+
+
+void SceneRenderer::bzdbCallback(const std::string& name, void *)
+{
+    if(name == "radarsize")
+        RENDERER.setRadarSize(BZDB.evalInt("radarsize"));
+    else if(name == "panelheight")
+        RENDERER.setPanelHeight(BZDB.evalInt("panelheight"));
 }
 
 

--- a/src/bzflag/bzflag.cxx
+++ b/src/bzflag/bzflag.cxx
@@ -631,10 +631,6 @@ void dumpResources()
 
     BZDB.set("radaropacity", TextUtils::format("%f", RENDERER.getRadarOpacity()));
 
-    BZDB.set("radarsize", TextUtils::format("%d", RENDERER.getRadarSize()));
-
-    BZDB.set("panelheight", TextUtils::format("%d", RENDERER.getPanelHeight()));
-
     BZDB.set("mouseboxsize", TextUtils::format("%d", RENDERER.getMaxMotionFactor()));
 
     // don't save these configurations


### PR DESCRIPTION
Previously the radar size and panel height were set initially by their BZDB variables at startup only and then changed directly from the settings menu. Now the BZDB variables are modified from settings instead and use a callback to change the SceneRenderer radar size and panel height.