### PR TITLE
Ignore the -NSDocumentRevisionsDebugMode option added by Xcode

### DIFF
--- a/README.MacOSX
+++ b/README.MacOSX
@@ -101,13 +101,6 @@ To build the client, select Build from the Product menu or enter the Command-B
 key sequence. Note that the BZFlag version is no longer automatically
 appended to the build product.
 
-NOTE: You may encounter the error "Unknown option
--NSDocumentRevisionsDebugMode" due to a deficiency in Xcode that prevents us
-from permanently disabling a certain setting. If you do encounter this error,
-click the "BZFlag" scheme button, click "Edit Scheme..." and under the "Options"
-tab, deselect "Allow debugging when using document Versions Browser" before
-running the client straight from Xcode.
-
 If the build was successful, you can run the application from Xcode selecting
 the Product menu and clicking Run or by entering the Command-R key sequence.
 You will also want to locate the application you just built. Make sure the

--- a/src/bzflag/bzflag.cxx
+++ b/src/bzflag/bzflag.cxx
@@ -533,6 +533,11 @@ static void     parse(int argc, char** argv)
         }
         else if (strcmp(argv[i], "-debug") == 0)
             debugLevel++;
+#ifdef __APPLE__
+        else if (strcmp(argv[i], "-NSDocumentRevisionsDebugMode") == 0)
+            // ignore this option that is appended when running from inside Xcode
+            checkArgc(i, argc, argv[i]);
+#endif // __APPLE__
         // has to be the last option that starts with -d
         else if (strncmp(argv[i], "-d", 2) == 0)
         {


### PR DESCRIPTION
Per our conversation on IRC regarding ignoring the "-NSDocumentRevisionsDebugMode YES" option when running from inside Xcode.

Once merged (and once 2.4 is merged into master again), we also need to remove https://github.com/BZFlag-Dev/bzflag/blob/master/README.premake5#L84-L91, and we need to edit https://github.com/BZFlag-Dev/bzflag.org/blob/master/_documentation/developer/pages/compiling-on-macos.md#73 to remove the sentence: "Go to the Product menu, then to Scheme, and click on Edit Scheme. Under the Options tab, uncheck 'Allow debugging when using document Versions Browser'."