### PR TITLE
simplify singleton pattern, silencing compile warnings for issue #176

### DIFF
--- a/include/CommandManager.h
+++ b/include/CommandManager.h
@@ -32,8 +32,8 @@ class CommandManager : public Singleton<CommandManager>
 
 public:
 
-    CommandManager();
-    ~CommandManager();
+    CommandManager() = default;
+    ~CommandManager() = default;
 
     // type of function that implements command.  function should return
     // a string with the output of the command (or the empty string if

--- a/include/Singleton.h
+++ b/include/Singleton.h
@@ -13,118 +13,42 @@
 #ifndef __SINGLETON_H__
 #define __SINGLETON_H__
 
-/* system headers */
-#ifdef HAVE_ATEXIT
-#   ifdef HAVE_CSTDLIB
-#include <cstdlib>
-using std::atexit;
-#   else
-#include <stdlib.h>
-#   endif
-#endif
-
 /* Singleton template class
+ *
+ * This template is based on an implementation suggested by Martin York in
+ * https://stackoverflow.com/a/1008289/9220132
  *
  * This template class pattern provides a traditional Singleton pattern.
  * Allows you to designate a single-instance global class by inheriting
- * off of the template class.
+ * from the template class.
  *
  * Example:
  *
  *   class Whatever : public Singleton<Whatever> ...
  *
- * The class will need to provide either a public or a protected friend
- * constructor:
+ * The class will need to provide an accessible default constructor
  *
- *   friend class Singleton<Whatever>;
- *
- * The class will also need to initialize it's own instance in a single
- * compilation unit (a .cxx file):
- *
- *   // statically initialize the instance to nothing
- *   template <>
- *   Whatever* Singleton<Whatever>::_instance = 0;
- *
- * The class can easily be extended to support different allocation
- * mechanisms or multithreading access.  This implementation, however,
- * only uses new/delete and is not thread safe.
- *
- * The Singleton will automatically get destroyed when the application
- * terminates (via an atexit() hook) unless the inheriting class has an
- * accessible destructor.
  */
 template < typename T >
 class Singleton
 {
-
-private:
-
-    static T* _instance;
-
-protected:
-
-    // protection from instantiating a non-singleton Singleton
-    Singleton() {}
-    Singleton(T* instancePointer)
-    {
-        _instance = instancePointer;
-    }
-    Singleton(const Singleton &) {} // do not use
-    Singleton& operator=(const Singleton&)
-    {
-        return *this;    // do not use
-    }
-    ~Singleton()
-    {
-        _instance = 0;    // do not delete
-    }
-
-    static void destroy()
-    {
-        if ( _instance != 0 )
-        {
-            delete(_instance);
-            _instance = 0;
-        }
-    }
-
 public:
 
     /** returns a singleton
      */
-    inline static T& instance()
+    static T& instance()
     {
-        if ( _instance == 0 )
-        {
-            _instance = new T;
-            // destroy the singleton when the application terminates
-#ifdef HAVE_ATEXIT
-            atexit(Singleton::destroy);
-#endif
-        }
-        return *Singleton::_instance;
+        static T private_instance;
+        return private_instance;
     }
 
-    /** returns a singleton pointer
-     */
-    inline static T* pInstance()
-    {
-        if (_instance == 0)
-        {
-            _instance = new T;
-#ifdef HAVE_ATEXIT
-            atexit(Singleton::destroy);
-#endif
-        }
-        return Singleton::_instance;
-    }
+    Singleton(const Singleton &) = delete;
+    Singleton& operator=(const Singleton&) = delete;
 
-    /** returns a const singleton reference
-     */
-    inline static const T& constInstance()
-    {
-        return *instance();
-    }
+protected:
+    Singleton() = default;
+    ~Singleton() = default;
+
 };
 
 #endif /* __SINGLETON_H__ */

--- a/include/StateDatabase.h
+++ b/include/StateDatabase.h
@@ -27,8 +27,6 @@
 #include "bzfio.h"
 #include "Singleton.h"
 
-#define BZDB (StateDatabase::instance())
-
 /** BZDB is the generic name:value pair database within bzflag and bzfs. Its
  * useful for data that can be serialized to a string that needs to be
  * accessible to many areas of the code. It also provides facilities for
@@ -440,6 +438,9 @@ inline bool StateDatabase::getSaveDefault() const
 std::istream& operator>>(std::istream& src, StateDatabase::Expression& dst);
 std::string& operator>>(std::string& src, StateDatabase::Expression& dst);
 std::ostream& operator<<(std::ostream& dst, const StateDatabase::Expression& src);
+
+#define BZDB (StateDatabase::instance())
+
 
 #endif // BZF_STATE_DATABASE_H
 

--- a/src/3D/FontManager.cxx
+++ b/src/3D/FontManager.cxx
@@ -36,11 +36,6 @@
 #include "ImageFont.h"
 #include "TextureFont.h"
 
-// initialize the singleton
-template <>
-FontManager* Singleton<FontManager>::_instance = (FontManager*)0;
-
-
 // ANSI code GLFloat equivalents - these should line up with the enums in AnsiCodes.h
 static GLfloat BrightColors[9][3] =
 {

--- a/src/3D/TextureManager.cxx
+++ b/src/3D/TextureManager.cxx
@@ -31,10 +31,6 @@
 
 /*const int NO_VARIANT = (-1); */
 
-// initialize the singleton
-template <>
-TextureManager* Singleton<TextureManager>::_instance = (TextureManager*)0;
-
 static int noiseProc(ProcTextureInit &init);
 
 ProcTextureInit procLoader[1];

--- a/src/bzadmin/UIMap.cxx
+++ b/src/bzadmin/UIMap.cxx
@@ -12,14 +12,6 @@
 
 #include "UIMap.h"
 
-// initialize the singleton
-template <>
-UIMap* Singleton<UIMap>::_instance = (UIMap*)0;
-
-UIMap::UIMap()
-{
-}
-
 UIAdder::UIAdder(const std::string& name, UICreator creator)
 {
     UIMap::instance()[name] = creator;

--- a/src/bzadmin/UIMap.h
+++ b/src/bzadmin/UIMap.h
@@ -41,7 +41,7 @@ class UIMap : public std::map<std::string, UICreator>,
 protected:
     friend class Singleton<UIMap>;
     /** The constructor is hidden, this is a singleton. */
-    UIMap();
+    UIMap() = default;
 
 };
 

--- a/src/bzflag/ActionBinding.cxx
+++ b/src/bzflag/ActionBinding.cxx
@@ -20,11 +20,6 @@
 #include "CommandManager.h"
 #include "KeyManager.h"
 
-// initialize the singleton
-template <>
-ActionBinding* Singleton<ActionBinding>::_instance = (ActionBinding*)0;
-
-
 ActionBinding::ActionBinding()
 {
     wayToBindActions.insert(std::make_pair(std::string("quit"), press));

--- a/src/bzflag/Roaming.cxx
+++ b/src/bzflag/Roaming.cxx
@@ -21,10 +21,6 @@
 /* local headers */
 #include "ScoreboardRenderer.h"
 
-// initialize the singleton
-template <>
-Roaming* Singleton<Roaming>::_instance = (Roaming*)0;
-
 Roaming::Roaming() : view(roamViewDisabled),
     targetManual(-1),
     targetWinner(-1),

--- a/src/bzflag/SceneRenderer.cxx
+++ b/src/bzflag/SceneRenderer.cxx
@@ -71,10 +71,6 @@ const float   SceneRenderer::dimDensity = 0.75f;
 const GLfloat SceneRenderer::dimnessColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
 const GLfloat SceneRenderer::blindnessColor[4] = { 1.0f, 1.0f, 0.0f, 1.0f };
 
-/* initialize the singleton */
-template <>
-SceneRenderer* Singleton<SceneRenderer>::_instance = (SceneRenderer*)0;
-
 SceneRenderer::SceneRenderer() :
     window(NULL),
     blank(false),

--- a/src/bzflag/effectsRenderer.cxx
+++ b/src/bzflag/effectsRenderer.cxx
@@ -247,9 +247,6 @@ protected:
     float radius;
 };
 
-template <>
-EffectsRenderer* Singleton<EffectsRenderer>::_instance = (EffectsRenderer*)0;
-
 // utils for geo
 static void drawRingYZ(float rad, float z, float topsideOffset = 0,
                        float bottomUV = 0, float ZOffset = 0,

--- a/src/common/CommandManager.cxx
+++ b/src/common/CommandManager.cxx
@@ -23,20 +23,6 @@
 #include "TextUtils.h"
 
 
-// initialize the singleton
-template <>
-CommandManager* Singleton<CommandManager>::_instance = (CommandManager*)0;
-
-CommandManager::CommandManager()
-{
-    // do nothing
-}
-
-CommandManager::~CommandManager()
-{
-    // do nothing
-}
-
 void                CommandManager::add(const std::string& name,
                                         CommandFunction func,
                                         const std::string& help)

--- a/src/common/ConfigFileManager.cxx
+++ b/src/common/ConfigFileManager.cxx
@@ -19,10 +19,6 @@
 
 static const int    MaximumLineLength = 1024;
 
-// initialize the singleton
-template <>
-ConfigFileManager* Singleton<ConfigFileManager>::_instance = (ConfigFileManager*)0;
-
 void writeBZDB(const std::string& name, void *stream)
 {
     std::ostream& s = *static_cast<std::ostream*>(stream);

--- a/src/common/FileManager.cxx
+++ b/src/common/FileManager.cxx
@@ -31,10 +31,6 @@
 // FileManager
 //
 
-// initialize the singleton
-template <>
-FileManager* Singleton<FileManager>::_instance = (FileManager*)0;
-
 FileManager::FileManager()
 {
     dataPath = "data";

--- a/src/common/KeyManager.cxx
+++ b/src/common/KeyManager.cxx
@@ -23,10 +23,6 @@
 // local implementation headers
 #include "BzfEvent.h"
 
-// initialize the singleton
-template <>
-KeyManager* Singleton<KeyManager>::_instance = (KeyManager*)0;
-
 const char*     KeyManager::buttonNames[] =
 {
     "???",

--- a/src/common/StateDatabase.cxx
+++ b/src/common/StateDatabase.cxx
@@ -75,11 +75,6 @@ void    _debugLookups(const std::string &name)
 #define debugLookups(name)
 #endif
 
-// initialize the singleton
-template <>
-StateDatabase* Singleton<StateDatabase>::_instance = (StateDatabase*)0;
-
-
 const std::string StateDatabase::BZDB_AGILITYADVEL     = std::string("_agilityAdVel");
 const std::string StateDatabase::BZDB_AGILITYTIMEWINDOW    = std::string("_agilityTimeWindow");
 const std::string StateDatabase::BZDB_AGILITYVELDELTA      = std::string("_agilityVelDelta");


### PR DESCRIPTION
The `Singleton` template was based on an older pattern that requires dynamic allocation and is not thread-safe. Based on [this pattern](https://stackoverflow.com/a/1008289/9220132) I re-factored the Singleton class, eliminating the class static member that was causing the warning.

On the whole, templates are hard to write. Older compilers were more forgiving about walking in the grey areas, but the language rules have gotten tighter. Template warnings should not be ignored. This implementation improves encapsulation by eliminating the need for template instantiators to know about the internal implementation details.

There are still a few other warnings, but I thought this merited a pull-request of its own.