### PR TITLE
Symbols hidden by default (and manually exported) when compiling with macOS using clang on master

### DIFF
--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -39,8 +39,13 @@
 #define strcasecmp stricmp
 #endif
 #else
+#ifdef __clang__
+#define BZF_API __attribute__((visibility("default")))
+#define BZF_PLUGIN_CALL extern "C" __attribute__((visibility("default")))
+#else
 #define BZF_API
 #define BZF_PLUGIN_CALL extern "C"
+#endif
 #endif
 
 /* Provide a means to deprecate API functions to discourage their use

--- a/premake5.lua
+++ b/premake5.lua
@@ -405,6 +405,7 @@ workspace(iif(_ACTION and string.find(_ACTION, "vs", 0),
 
   filter "system:macosx"
     defines "HAVE_CGLGETCURRENTCONTEXT"
+    buildoptions "-fvisibility=hidden"
     xcodebuildsettings { ["CLANG_CXX_LIBRARY"] = "libc++",
                          ["MACOSX_DEPLOYMENT_TARGET"] = "10.9",
                          ["LD_RUNPATH_SEARCH_PATHS"] =" @executable_path/../PlugIns" }


### PR DESCRIPTION
This and #203 combine to fix the two warnings when compiling on macOS described in #176. This is the fix for master, and #206 was opened for the 2.4 branch