### PR TITLE
Cleanup for consistency with mesh rendering

### DIFF
--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -6075,17 +6075,6 @@ void drawFrame(const float dt)
 
             // add explosions
             addExplosions(scene);
-
-            // if inside a building, add some eighth dimension scene nodes.
-            const std::vector<const Obstacle*>& list = myTank->getInsideBuildings();
-            for (unsigned int n = 0; n < list.size(); n++)
-            {
-                const Obstacle* obs = list[n];
-                const int nodeCount = obs->getInsideSceneNodeCount();
-                SceneNode** nodeList = obs->getInsideSceneNodeList();
-                for (int o = 0; o < nodeCount; o++)
-                    scene->addDynamicNode(nodeList[o]);
-            }
         }
 
         // turn blanking and inversion on/off as appropriate


### PR DESCRIPTION
Fixes inconsistent rendering in OO with mesh and non-mesh objects.
In reference to the [Eighth dimension cleanup/removal](https://forums.bzflag.org/viewtopic.php?f=3&t=20170) forum thread.

For the next major release some cleanup will be needed, but for now this is a minor edit which works well as it does not introduce any game play inconsistencies which might result otherwise.