### PR TITLE
Add bz_eReloadEvent API event

### DIFF
--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -338,6 +338,7 @@ typedef enum
     bz_ePermissionModificationEvent,
     bz_eAllowServerShotFiredEvent,
     bz_ePlayerDeathFinalizedEvent,
+    bz_eReloadEvent,
     bz_eLastEvent    //this is never used as an event, just show it's the last one
 } bz_eEventType;
 
@@ -1460,6 +1461,20 @@ public:
     bool customPerm;
 };
 
+class BZF_API bz_ReloadData_V1 : public bz_EventData
+{
+public:
+    bz_ReloadData_V1() : bz_EventData(bz_eReloadEvent)
+        , playerID(-1)
+        , target("all")
+        , handled(false)
+    {}
+
+    int playerID;
+    const char* target;
+    bool handled;
+};
+
 // logging
 BZF_API void bz_debugMessage ( int debugLevel, const char* message );
 BZF_API void bz_debugMessagef( int debugLevel, const char* fmt, ... );
@@ -2163,6 +2178,7 @@ BZF_API void bz_gameOver(int playerID, bz_eTeamType team = eNoTeam);
 BZF_API bool bz_restart ( void );
 BZF_API const char* bz_getServerOwner();
 
+BZF_API void bz_reloadAll();
 BZF_API void bz_reloadLocalBans();
 BZF_API void bz_reloadMasterBans();
 BZF_API void bz_reloadGroups();

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -4286,10 +4286,29 @@ BZF_API const char* bz_getServerOwner()
     return getPublicOwner().c_str();
 }
 
+BZF_API void bz_reloadAll()
+{
+    bz_ReloadData_V1 event;
+    event.target = "all";
+    worldEventManager.callEvents(bz_eReloadEvent, &event);
+
+    bz_reloadLocalBans();
+    bz_reloadMasterBans();
+    bz_reloadGroups();
+    bz_reloadUsers();
+    bz_reloadHelp();
+    bz_reloadBadwords();
+}
+
 BZF_API void bz_reloadLocalBans()
 {
     // reload the banlist
     logDebugMessage(3,"Reloading bans\n");
+
+    bz_ReloadData_V1 event;
+    event.target = "bans";
+    worldEventManager.callEvents(bz_eReloadEvent, &event);
+
     clOptions->acl.load();
 
     rescanForBans();
@@ -4302,6 +4321,11 @@ BZF_API void bz_reloadMasterBans()
 
     // reload the banlist
     logDebugMessage(3,"Reloading master bans\n");
+
+    bz_ReloadData_V1 event;
+    event.target = "masterbans";
+    worldEventManager.callEvents(bz_eReloadEvent, &event);
+
     clOptions->acl.purgeMasters();
 
     masterBanHandler.start();
@@ -4310,6 +4334,11 @@ BZF_API void bz_reloadMasterBans()
 BZF_API void bz_reloadGroups()
 {
     logDebugMessage(3,"Reloading groups\n");
+
+    bz_ReloadData_V1 event;
+    event.target = "groups";
+    worldEventManager.callEvents(bz_eReloadEvent, &event);
+
     groupAccess.clear();
     initGroups();
 }
@@ -4317,6 +4346,12 @@ BZF_API void bz_reloadGroups()
 BZF_API void bz_reloadUsers()
 {
     logDebugMessage(3,"Reloading users\n");
+
+    bz_ReloadData_V1 event;
+    event.target = "users";
+    worldEventManager.callEvents(bz_eReloadEvent, &event);
+
+
     userDatabase.clear();
 
     if (userDatabaseFile.size())
@@ -4328,12 +4363,23 @@ BZF_API void bz_reloadHelp()
 {
     // reload the text chunks
     logDebugMessage(3,"Reloading helpfiles\n");
+
+    bz_ReloadData_V1 event;
+    event.target = "helpfiles";
+    worldEventManager.callEvents(bz_eReloadEvent, &event);
+
+
     clOptions->textChunker.reload();
 }
 
 BZF_API void bz_reloadBadwords()
 {
     logDebugMessage(3,"Reloading bad words\n");
+
+    bz_ReloadData_V1 event;
+    event.target = "badwords";
+    worldEventManager.callEvents(bz_eReloadEvent, &event);
+
     clOptions->filter.clear();
     loadBadwordsList();
 }

--- a/src/bzfs/commands.cxx
+++ b/src/bzfs/commands.cxx
@@ -2762,6 +2762,12 @@ bool ReloadCommand::operator() (const char   *message,
 
     logDebugMessage(3,"Command is %s\n", cmd.c_str());
 
+    bz_ReloadData_V1 event;
+    event.playerID = t;
+    event.target = cmd.c_str();
+
+    worldEventManager.callEvents(bz_eReloadEvent, &event);
+
     /* handle subcommands */
 
     bool reload_bans = false;
@@ -2769,6 +2775,7 @@ bool ReloadCommand::operator() (const char   *message,
     bool reload_users = false;
     bool reload_helpfiles = false;
     bool reload_badwords = false;
+
     if ((cmd == "") || (cmd == "all"))
     {
         logDebugMessage(3,"Reload all\n");
@@ -2805,8 +2812,14 @@ bool ReloadCommand::operator() (const char   *message,
     }
     else
     {
+        // Allow a plug-in to take over
+        if (event.handled) {
+            return true;
+        }
+
         sendMessage(ServerPlayer, t, "Invalid option for the reload command");
         sendMessage(ServerPlayer, t, "Usage: /reload [all|bans|badwords|helpfiles|groups|users]");
+
         return true; // Bail out
     }
 


### PR DESCRIPTION
This PR will allow plug-ins to safely and easily hook into `/reload` and `bz_reload*()` events. This will also allow for custom `/reload` subcommands without needing to overload the `/reload` command.

The reason behind this change is to allow plugins to have custom reload functionality.