### PR TITLE
Fix missing include

### DIFF
--- a/src/common/TimeKeeper.cxx
+++ b/src/common/TimeKeeper.cxx
@@ -14,6 +14,7 @@
 #include "TimeKeeper.h"
 
 /* system implementation headers */
+#include <cstring>
 #include <thread>
 
 /* common implementation headers */


### PR DESCRIPTION
Causes issues in newer versions of GCC.

Broken since aa19b4eb0b064bc8e83b47337916d5caedd0bcac