### PR TITLE
Nethandler issue 205

### DIFF
--- a/include/Ping.h
+++ b/include/Ping.h
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file
@@ -21,7 +21,6 @@
 /* common interface headers */
 #include "Address.h"
 #include "Pack.h"
-#include "multicast.h"
 
 
 // 8 uint16's and 13 uint8's hex encoded
@@ -56,16 +55,16 @@ public:
     static bool sendRequest(int fd, const struct sockaddr_in*);
 
 public:
-    ServerId        serverId;
+    ServerId    serverId;
     Address     sourceAddr;
-    uint16_t        gameOptions;
-    uint16_t        gameType;
-    uint16_t        maxShots;
-    uint16_t        shakeWins;
-    uint16_t        shakeTimeout;       // 1/10ths of second
-    uint16_t        maxPlayerScore;
-    uint16_t        maxTeamScore;
-    uint16_t        maxTime;        // seconds
+    uint16_t    gameOptions;
+    uint16_t    gameType;
+    uint16_t    maxShots;
+    uint16_t    shakeWins;
+    uint16_t    shakeTimeout;       // 1/10ths of second
+    uint16_t    maxPlayerScore;
+    uint16_t    maxTeamScore;
+    uint16_t    maxTime;            // seconds
     uint8_t     maxPlayers;
     uint8_t     rogueCount;
     uint8_t     rogueMax;

--- a/include/ServerItem.h
+++ b/include/ServerItem.h
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file
@@ -16,9 +16,8 @@
 #include "common.h"
 
 /* system interface headers */
-#include <iostream>
 #include <string>
-#include <time.h>
+#include <ctime>
 
 /* common interface headers */
 #include "Ping.h"

--- a/include/network.h
+++ b/include/network.h
@@ -80,10 +80,10 @@ using AddrLen = socklen_t;
 /* setsockopt prototypes the 4th arg as const char*. */
 using SSOType = char const*;
 /* connect prototypes the 2nd arg without const */
-//using CNCTType = sockaddr;
+using CNCTType = sockaddr; // only appears used in bzadmin
 # else
 using SSOType  = void const*;
-//using CNCTType = sockaddr const;
+using CNCTType = sockaddr const; // only appears used in bzadmin
 # endif
 
 // This is extremely questionable. herror() is defined in netdb.h for Linux

--- a/src/bzadmin/ServerLink.cxx
+++ b/src/bzadmin/ServerLink.cxx
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file

--- a/src/bzadmin/StdBothUI.cxx
+++ b/src/bzadmin/StdBothUI.cxx
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file
@@ -20,11 +20,10 @@
 #  include <stdlib.h>
 #  include <wincon.h>
 #else
+#  include <cstring>
+#  include <unistd.h>
 #  include <sys/types.h>
 #  include <sys/select.h>
-#  ifdef HAVE_STRING_H
-#    include <string.h> // on Solaris FD_ZERO() is a macro that uses memset()
-#  endif
 #endif
 
 /* implementation headers */

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file
@@ -4817,7 +4817,7 @@ static void     addRobots()
         }
         else
         {
-            snprintf(callsign, CallSignLen, "%.29s%2.2hhx", myTank->getCallSign(), j);
+            snprintf(callsign, CallSignLen, "%.29s%2.2x", myTank->getCallSign(), j);
             robots[j] = new RobotPlayer(robotServer[j]->getId(), callsign,
                                         robotServer[j], myTank->getMotto());
             robots[j]->setTeam(AutomaticTeam);

--- a/src/game/ServerItem.cxx
+++ b/src/game/ServerItem.cxx
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file
@@ -10,14 +10,12 @@
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "common.h"
+/* interface header */
+#include "ServerItem.h"
 
 /* system headers */
 #include <string>
-#include <string.h>
-
-/* interface header */
-#include "ServerItem.h"
+#include <cstring>
 
 /* common implementation headers */
 #include "TextUtils.h"
@@ -161,16 +159,11 @@ std::string ServerItem::getAgeString() const
     return returnMe;
 }
 
-// get the current time
+// get the current time -- one-line functions add little value ...
+// replace with native std::time()?
 time_t ServerItem::getNow() const
 {
-#if defined(_WIN32)
-    return time(NULL);
-#else
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return tv.tv_sec;
-#endif
+    return std::time(nullptr);
 }
 
 bool ServerItem::operator<(const ServerItem &right)

--- a/src/game/ServerList.cxx
+++ b/src/game/ServerList.cxx
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file
@@ -14,23 +14,13 @@
 #include "ServerList.h"
 
 /* system headers */
-#include <iostream>
-#include <vector>
-#include <string>
-#include <string.h>
-#if !defined(_WIN32)
-#include <errno.h>
-#endif
-#include <ctype.h>
 
 /* common implementation headers */
 #include "version.h"
-#include "bzsignal.h"
-#include "Ping.h"
 #include "Protocol.h"
-#include "TimeKeeper.h"
 #include "TextUtils.h"
 #include "ErrorHandler.h"
+#include "multicast.h"
 
 /* local implementation headers */
 #include "ServerListCache.h"

--- a/src/game/ServerList.cxx
+++ b/src/game/ServerList.cxx
@@ -14,6 +14,7 @@
 #include "ServerList.h"
 
 /* system headers */
+#include <cstring>
 
 /* common implementation headers */
 #include "version.h"

--- a/src/net/AresHandler.cxx
+++ b/src/net/AresHandler.cxx
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file
@@ -12,11 +12,10 @@
 
 /* interface header */
 #include "AresHandler.h"
-#include "Address.h"
 
 /* system implementation headers */
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 
 bool AresHandler::globallyInited = false;
 

--- a/src/net/Ping.cxx
+++ b/src/net/Ping.cxx
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file
@@ -14,17 +14,16 @@
 #include "Ping.h"
 
 /* system implementation headers */
-#include <string.h>
-#include <math.h>
-#include <ctype.h>
+#include <cstring>
+#include <cmath>
+#include <cctype>
 
 /* common implementation headers */
-#include "global.h"
 #include "Protocol.h"
 #include "TimeKeeper.h"
-#include "bzfio.h"
+#include "multicast.h"
 
-// incessint rebuilding for current versioning
+// incessant rebuilding for current versioning
 #include "version.h"
 
 

--- a/src/net/multicast.cxx
+++ b/src/net/multicast.cxx
@@ -19,6 +19,13 @@
 #include <vector>
 #include <string>
 
+#if defined(__linux__)
+// This is inherently non-portable, as device handling varies from OS to OS
+// Debian requires the explicit include. Apparently Alpine does as well
+#include <sys/ioctl.h>
+#include <net/if.h>
+#endif
+
 /* common implementation headers */
 #include "ErrorHandler.h"
 

--- a/src/net/multicast.cxx
+++ b/src/net/multicast.cxx
@@ -27,7 +27,8 @@ inline int close(SOCKET s)
 #else
 # include <unistd.h>	// close()
 # include <netdb.h>     // getservbyname
-# include <net/if.h>    // Ubuntu (at least) requires the explicit include
+# include <sys/ioctl.h> // Ubuntu (at least) requires the explicit includes
+# include <net/if.h>    //
 /* BeOS net_server has closesocket(), which _must_ be used in place of close() */
 # if defined(__BEOS__) && (IPPROTO_TCP != 6)
 #  define close(__x) closesocket(__x)

--- a/src/net/multicast.cxx
+++ b/src/net/multicast.cxx
@@ -1,5 +1,5 @@
 /* bzflag
- * Copyright (c) 1993-2018 Tim Riker
+ * Copyright (c) 1993-2019 Tim Riker
  *
  * This package is free software;  you can redistribute it and/or
  * modify it under the terms of the license found in the file
@@ -11,19 +11,29 @@
  */
 
 /* interface header */
-#include "multicast.h"
+#include "multicast.h" // includes network.h
 
-/* system implementation headers */
-#ifdef _WIN32
-#  include <winsock2.h>
-#  include <ws2tcpip.h>
-#endif
-
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
 #include <vector>
 #include <string>
+
+#ifdef _WIN32
+inline int close(SOCKET s)
+{
+  return closesocket(s);
+}
+#else
+# include <unistd.h>	// close()
+# include <netdb.h>     // getservbyname
+/* BeOS net_server has closesocket(), which _must_ be used in place of close() */
+# if defined(__BEOS__) && (IPPROTO_TCP != 6)
+#  define close(__x) closesocket(__x)
+# endif
+
+
+#endif
 
 /* common implementation headers */
 #include "ErrorHandler.h"

--- a/src/net/multicast.cxx
+++ b/src/net/multicast.cxx
@@ -27,6 +27,7 @@ inline int close(SOCKET s)
 #else
 # include <unistd.h>	// close()
 # include <netdb.h>     // getservbyname
+# include <net/if.h>    // Ubuntu (at least) requires the explicit include
 /* BeOS net_server has closesocket(), which _must_ be used in place of close() */
 # if defined(__BEOS__) && (IPPROTO_TCP != 6)
 #  define close(__x) closesocket(__x)

--- a/src/net/multicast.cxx
+++ b/src/net/multicast.cxx
@@ -19,24 +19,6 @@
 #include <vector>
 #include <string>
 
-#ifdef _WIN32
-inline int close(SOCKET s)
-{
-  return closesocket(s);
-}
-#else
-# include <unistd.h>	// close()
-# include <netdb.h>     // getservbyname
-# include <sys/ioctl.h> // Ubuntu (at least) requires the explicit includes
-# include <net/if.h>    //
-/* BeOS net_server has closesocket(), which _must_ be used in place of close() */
-# if defined(__BEOS__) && (IPPROTO_TCP != 6)
-#  define close(__x) closesocket(__x)
-# endif
-
-
-#endif
-
 /* common implementation headers */
 #include "ErrorHandler.h"
 

--- a/src/net/network.cxx
+++ b/src/net/network.cxx
@@ -13,18 +13,19 @@
 #include "network.h"
 
 //Includes common to all platforms
-#include "ErrorHandler.h"
-#include "Address.h"
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <vector>
 #include <string>
+
+#include "ErrorHandler.h"
 
 #if !defined(WIN32)
 
 #include <fcntl.h>
 #include <ctype.h>
 #include <errno.h>
+#include <netdb.h>
 
 #if defined(sun)
 #define hstrerror(x) "<network error>"


### PR DESCRIPTION
This PR cleans up the platform-dependent code in network.h that led to #205. It also starts to reduce the profligate including of headers that makes this code base such a mess.

The basic issue is that there was a logic hole in all the #ifdefs that allowed a Linux system to define `AddrLen` as `int` instead of as `socklen_t`

It has not been astyled; I'll take that criticism if levied. I'd like to figure out a way to enforce it and not rely on the good manners of developers.

As usual, I probably went farther than a single PR should