### PR TITLE
Texture conversion to internal format done only once.

### DIFF
--- a/include/OpenGLTexture.h
+++ b/include/OpenGLTexture.h
@@ -64,8 +64,7 @@ public:
     OpenGLTexture(int width, int height,
                   const GLvoid* pixels,
                   Filter maxFilter = Linear,
-                  bool repeat = true,
-                  int internalFormat = 0);
+                  bool repeat = true);
     ~OpenGLTexture();
     bool        hasAlpha() const;
 
@@ -77,9 +76,6 @@ public:
 
     Filter      getFilter();
     void        setFilter(Filter);
-
-    bool        getColorAverages(float rgbaRaw[4],
-                                 bool factorAlpha) const;
 
     void        freeContext();
     void        initContext();
@@ -99,10 +95,9 @@ private:
     bool        operator==(const OpenGLTexture&) const;
     bool        operator!=(const OpenGLTexture&) const;
     bool        operator<(const OpenGLTexture&) const;
-    int         getBestFormat(int width, int height,
-                              const GLvoid* pixels);
+    void        getBestFormat();
     void        bind();
-    bool        setupImage(const GLubyte* pixels);
+    void        setupImage(const GLubyte* pixels);
 
     void* operator new(size_t s)
     {

--- a/include/TextureManager.h
+++ b/include/TextureManager.h
@@ -67,8 +67,6 @@ public:
     const ImageInfo& getInfo ( int id );
     const ImageInfo& getInfo ( const char* name );
 
-    bool getColorAverages(int texId, float rgba[4], bool factorAlpha) const;
-
     OpenGLTexture::Filter getMaxFilter ( void );
     std::string getMaxFilterName ( void );
     void setMaxFilter ( OpenGLTexture::Filter filter );
@@ -77,7 +75,7 @@ public:
     float GetAspectRatio ( int id );
 
     int newTexture (const char* name, int x, int y, unsigned char* data,
-                    OpenGLTexture::Filter filter, bool repeat = true, int format = 0);
+                    OpenGLTexture::Filter filter, bool repeat = true);
 protected:
     friend class Singleton<TextureManager>;
 

--- a/src/3D/TextureManager.cxx
+++ b/src/3D/TextureManager.cxx
@@ -309,19 +309,6 @@ const ImageInfo& TextureManager::getInfo ( const char* name )
 }
 
 
-bool TextureManager::getColorAverages(int texId, float rgba[4],
-                                      bool factorAlpha) const
-{
-    TextureIDMap::const_iterator it = textureIDs.find(texId);
-    if (it == textureIDs.end())
-    {
-        logDebugMessage(1,"getColorAverages: Unable to find texture (by id): %d\n", texId);
-        return false;
-    }
-    return it->second->texture->getColorAverages(rgba, factorAlpha);
-}
-
-
 int TextureManager::addTexture( const char* name, OpenGLTexture *texture )
 {
     if (!name || !texture)
@@ -378,9 +365,9 @@ OpenGLTexture* TextureManager::loadTexture(FileTextureInit &init, bool reportFai
 
 
 int TextureManager::newTexture(const char* name, int x, int y, unsigned char* data,
-                               OpenGLTexture::Filter filter, bool repeat, int format)
+                               OpenGLTexture::Filter filter, bool repeat)
 {
-    return addTexture(name, new OpenGLTexture(x, y, data, filter, repeat, format));
+    return addTexture(name, new OpenGLTexture(x, y, data, filter, repeat));
 }
 
 

--- a/src/ogl/OpenGLTexture.cxx
+++ b/src/ogl/OpenGLTexture.cxx
@@ -76,21 +76,18 @@ OpenGLTexture::Filter OpenGLTexture::maxFilter = Default;
 
 
 OpenGLTexture::OpenGLTexture(int _width, int _height, const GLvoid* pixels,
-                             Filter _filter, bool _repeat, int _internalFormat) :
+                             Filter _filter, bool _repeat) :
     width(_width), height(_height)
 {
-    alpha = false;
     repeat = _repeat;
-    internalFormat = _internalFormat;
     filter = _filter;
     list = INVALID_GL_TEXTURE_ID;
 
-    // get internal format if not provided
-    if (internalFormat == 0)
-        internalFormat = getBestFormat(width, height, pixels);
-
     // copy/scale the original texture image
     setupImage((const GLubyte*)pixels);
+
+    // get internal format
+    getBestFormat();
 
     // build and bind the GL texture
     initContext();
@@ -153,13 +150,13 @@ void OpenGLTexture::initContext()
         glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
         glTexImage2D(GL_TEXTURE_2D, 0, internalFormat,
                      scaledWidth, scaledHeight,
-                     0, GL_RGBA, GL_UNSIGNED_BYTE, image);
+                     0, internalFormat, GL_UNSIGNED_BYTE, image);
     }
     else
     {
         gluBuild2DMipmaps(GL_TEXTURE_2D, internalFormat,
                           scaledWidth, scaledHeight,
-                          GL_RGBA, GL_UNSIGNED_BYTE, image);
+                          internalFormat, GL_UNSIGNED_BYTE, image);
     }
     glBindTexture(GL_TEXTURE_2D, 0);
 
@@ -167,7 +164,7 @@ void OpenGLTexture::initContext()
 }
 
 
-bool OpenGLTexture::setupImage(const GLubyte* pixels)
+void OpenGLTexture::setupImage(const GLubyte* pixels)
 {
     if (GLEW_ARB_texture_non_power_of_two)
     {
@@ -232,30 +229,6 @@ bool OpenGLTexture::setupImage(const GLubyte* pixels)
     // set the image
     image = aligned;
     imageMemory = unaligned;
-
-    // note if internal format uses alpha
-    switch (internalFormat)
-    {
-    case GL_LUMINANCE_ALPHA:
-#if defined(GL_LUMINANCE4_ALPHA4)
-    case GL_LUMINANCE4_ALPHA4:
-#elif defined(GL_LUMINANCE4_ALPHA4_EXT)
-    case GL_LUMINANCE4_ALPHA4_EXT:
-#endif
-    case GL_RGBA:
-#if defined(GL_INTENSITY4)
-    case GL_INTENSITY4:
-#elif defined(GL_INTENSITY4_EXT)
-    case GL_INTENSITY4_EXT:
-#endif
-        alpha = true;
-        break;
-    default:
-        alpha = false;
-        break;
-    }
-
-    return true;
 }
 
 
@@ -358,90 +331,50 @@ void OpenGLTexture::bind()
 }
 
 
-int OpenGLTexture::getBestFormat(int _width, int _height, const GLvoid* pixels)
+void OpenGLTexture::getBestFormat()
 {
-    // see if all pixels are achromatic
-    const GLubyte* scan = (const GLubyte*)pixels;
-    const int size = _width * _height;
+    GLubyte* scan = image;
+    const int size = scaledWidth * scaledHeight;
     int i;
+    bool useLuminance = true;
+    alpha = false;
     for (i = 0; i < size; scan += 4, i++)
-        if (scan[0] != scan[1] || scan[0] != scan[2])
-            break;
-    const bool useLuminance = (i == size);
-
-    // see if all pixels are opaque
-    scan = (const GLubyte*)pixels;
-    for (i = 0; i < size; scan += 4, i++)
-        if (scan[3] != 0xff)
-            break;
-    const bool useAlpha = (i != size);
-
-    bool useIntensity = false;
-    if (useLuminance)
     {
-        scan = (const GLubyte*)pixels;
-        for (i = 0; i < size; scan += 4, i++)
-            if (scan[3] != scan[0])
-                break;
-        useIntensity = (i == size);
+        // see if all pixels are achromatic
+        if (scan[0] != scan[1] || scan[0] != scan[2])
+            useLuminance = false;
+        // see if all pixels are opaque
+        if (scan[3] != 0xff)
+            alpha = true;
+        if (!useLuminance && alpha)
+            break;
     }
-    if (useIntensity)
-        return GL_INTENSITY;
+
+    scan = image;
+    GLubyte* scanOut = image;
+    for (i = 0; i < size; i++)
+    {
+        *scanOut++ = *scan++;
+        if (useLuminance)
+        {
+            scan++;
+            scan++;
+        }
+        else
+        {
+            *scanOut++ = *scan++;
+            *scanOut++ = *scan++;
+        }
+        if (alpha)
+            *scanOut++ = *scan++;
+        else
+            scan++;
+    }
 
     // pick internal format
-    return (useLuminance ?
-            (useAlpha ? GL_LUMINANCE_ALPHA : GL_LUMINANCE) :
-            (useAlpha ? GL_RGBA : GL_RGB));
-}
-
-
-bool OpenGLTexture::getColorAverages(float rgba[4], bool factorAlpha) const
-{
-    if ((image == NULL) || (scaledWidth <= 0) || (scaledHeight <= 0))
-        return false;
-
-    factorAlpha = (factorAlpha && alpha);
-    const int channelCount = alpha ? 4 : 3;
-
-    // tally the values
-    s64 rgbaTally[4] = {0, 0, 0, 0};
-    for (int x = 0; x < scaledWidth; x++)
-    {
-        for (int y = 0; y < scaledHeight; y++)
-        {
-            for (int c = 0; c < channelCount; c++)
-            {
-                const int pixelBase = 4 * (x + (y * scaledWidth));
-                if (factorAlpha)
-                {
-                    const GLubyte alphaVal = image[pixelBase + 3];
-                    if (c == 3)
-                        rgbaTally[3] += alphaVal;
-                    else
-                        rgbaTally[c] += image[pixelBase + c] * alphaVal;
-                }
-                else
-                    rgbaTally[c] += image[pixelBase + c];
-            }
-        }
-    }
-
-    // calculate the alpha average
-    float maxTally = 255.0f * (scaledWidth * scaledHeight);
-    if (channelCount == 3)
-        rgba[3] = 1.0f;
-    else
-        rgba[3] = (float)rgbaTally[3] / maxTally;
-
-    // adjust the maxTally for alpha weighting
-    if (factorAlpha)
-        maxTally = maxTally * 255.0f;
-
-    // calcualte the color averages
-    for (int c = 0; c < 3; c++)
-        rgba[c] = (float)rgbaTally[c] / maxTally;
-
-    return true;
+    internalFormat = useLuminance ?
+                     (alpha ? GL_LUMINANCE_ALPHA : GL_LUMINANCE) :
+                     (alpha ? GL_RGBA : GL_RGB);
 }
 
 


### PR DESCRIPTION
changes to OpenGLTexture:
- GL_INTENSITY internal format removed (deprecated on GLES)
- conversion from external format to internal format made only at texture creation
- glTexImage called with the same internalFormat and externalFomat 