### PR TITLE
Require openGL context 2.1

### DIFF
--- a/include/OpenGLTexture.h
+++ b/include/OpenGLTexture.h
@@ -113,8 +113,6 @@ private:
     bool        alpha;
     const int       width;
     const int       height;
-    GLint       scaledWidth;
-    GLint       scaledHeight;
     GLubyte*        image;
     GLubyte*        imageMemory;
     bool        repeat;

--- a/include/bzfgl.h
+++ b/include/bzfgl.h
@@ -20,8 +20,8 @@
 #include <iostream>
 #include <GL/glew.h>
 
-#ifndef GL_VERSION_1_1
-# error OpenGL version 1.1 functionality is required
+#ifndef GL_VERSION_2_1
+# error OpenGL version 2.1 functionality is required
 #endif
 
 

--- a/src/bzflag/BackgroundRenderer.cxx
+++ b/src/bzflag/BackgroundRenderer.cxx
@@ -795,12 +795,6 @@ void BackgroundRenderer::setupSkybox()
     for (i = 0; i < 6; i++)
         bzmats[i]->setReference();
 
-    // setup the wrap mode
-    if (GLEW_EXT_texture_edge_clamp)
-        skyboxWrapMode = GL_CLAMP_TO_EDGE;
-    else
-        skyboxWrapMode = GL_CLAMP;
-
     // setup the corner colors
     const int cornerFaces[8][3] =
     {
@@ -853,8 +847,8 @@ void BackgroundRenderer::drawSkybox()
     if (!BZDBCache::drawGround)
     {
         tm.bind(skyboxTexID[5]); // bottom
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, skyboxWrapMode);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, skyboxWrapMode);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
         glBegin(GL_TRIANGLE_STRIP);
         {
             glTexCoord2fv(txcds[0]);
@@ -874,8 +868,8 @@ void BackgroundRenderer::drawSkybox()
     }
 
     tm.bind(skyboxTexID[4]); // top
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, skyboxWrapMode);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, skyboxWrapMode);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glBegin(GL_TRIANGLE_STRIP);
     {
         glTexCoord2fv(txcds[0]);
@@ -894,8 +888,8 @@ void BackgroundRenderer::drawSkybox()
     glEnd();
 
     tm.bind(skyboxTexID[0]); // left
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, skyboxWrapMode);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, skyboxWrapMode);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glBegin(GL_TRIANGLE_STRIP);
     {
         glTexCoord2fv(txcds[0]);
@@ -914,8 +908,8 @@ void BackgroundRenderer::drawSkybox()
     glEnd();
 
     tm.bind(skyboxTexID[1]); // front
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, skyboxWrapMode);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, skyboxWrapMode);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glBegin(GL_TRIANGLE_STRIP);
     {
         glTexCoord2fv(txcds[0]);
@@ -934,8 +928,8 @@ void BackgroundRenderer::drawSkybox()
     glEnd();
 
     tm.bind(skyboxTexID[2]); // right
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, skyboxWrapMode);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, skyboxWrapMode);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glBegin(GL_TRIANGLE_STRIP);
     {
         glTexCoord2fv(txcds[0]);
@@ -954,8 +948,8 @@ void BackgroundRenderer::drawSkybox()
     glEnd();
 
     tm.bind(skyboxTexID[3]); // back
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, skyboxWrapMode);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, skyboxWrapMode);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glBegin(GL_TRIANGLE_STRIP);
     {
         glTexCoord2fv(txcds[0]);

--- a/src/bzflag/BackgroundRenderer.h
+++ b/src/bzflag/BackgroundRenderer.h
@@ -138,7 +138,6 @@ private:
 
     // celestial stuff
     bool        haveSkybox;
-    GLenum      skyboxWrapMode;
     int         skyboxTexID[6];
     GLfloat     skyboxColor[8][4];
     bool        doStars;

--- a/src/bzflag/SceneRenderer.cxx
+++ b/src/bzflag/SceneRenderer.cxx
@@ -273,21 +273,10 @@ void SceneRenderer::setQuality(int value)
     // highlighting when applied to a dark textured surface.
     // It was mainlined in OpenGL Version 1.2
     // (there's also the GL_EXT_separate_specular_color extension)
-#ifdef GL_LIGHT_MODEL_COLOR_CONTROL
     if (useQualityValue >= 1)
         glLightModeli(GL_LIGHT_MODEL_COLOR_CONTROL, GL_SEPARATE_SPECULAR_COLOR);
     else
         glLightModeli(GL_LIGHT_MODEL_COLOR_CONTROL, GL_SINGLE_COLOR);
-#  else // in case someone includes <GL/glext.h> at some point
-#  ifdef GL_LIGHT_MODEL_COLOR_CONTROL_EXT
-    if (useQualityValue >= 1)
-        glLightModeli(GL_LIGHT_MODEL_COLOR_CONTROL_EXT,
-                      GL_SEPARATE_SPECULAR_COLOR_EXT);
-    else
-        glLightModeli(GL_LIGHT_MODEL_COLOR_CONTROL_EXT,
-                      GL_SINGLE_COLOR_EXT);
-#  endif
-#endif
 
     BZDB.set("useQuality", TextUtils::format("%d", value));
 }

--- a/src/bzflag/bzflag.cxx
+++ b/src/bzflag/bzflag.cxx
@@ -1288,11 +1288,9 @@ int         main(int argc, char** argv)
             case GL_OUT_OF_MEMORY:
                 std::cerr << "ERROR: GL_OUT_OF_MEMORY" << std::endl;
                 break;
-#ifdef GL_VERSION_1_2
             case GL_TABLE_TOO_LARGE:
                 std::cerr << "ERROR: GL_TABLE_TOO_LARGE" << std::endl;
                 break;
-#endif
             case GL_NO_ERROR:
                 // should not reach
                 std::cerr << "ERROR: GL_NO_ERROR" << std::endl;

--- a/src/geometry/SphereSceneNode.cxx
+++ b/src/geometry/SphereSceneNode.cxx
@@ -365,11 +365,7 @@ void SphereLodSceneNode::SphereLodRenderNode::render()
 
     glEnable(GL_CLIP_PLANE0);
 
-#ifdef GL_VERSION_1_2
     glEnable(GL_RESCALE_NORMAL);
-#else
-    glEnable(GL_NORMALIZE);
-#endif
 
     const bool transparent = sceneNode->transparent;
     const bool stippled = transparent && !BZDBCache::blend;
@@ -451,11 +447,7 @@ void SphereLodSceneNode::SphereLodRenderNode::render()
     }
     glPopMatrix();
 
-#ifdef GL_VERSION_1_2
     glDisable(GL_RESCALE_NORMAL);
-#else
-    glDisable(GL_NORMALIZE);
-#endif
 
     glDisable(GL_CLIP_PLANE0);
 
@@ -630,11 +622,7 @@ void            SphereBspSceneNode::SphereBspRenderNode::render()
         myStipple(sceneNode->color[3]);
     if (BZDBCache::lighting)
     {
-#ifdef GL_VERSION_1_2
         glEnable(GL_RESCALE_NORMAL);
-#else
-        glEnable(GL_NORMALIZE);
-#endif
         // draw with normals (normal is same as vertex!
         // one of the handy properties of a sphere.)
         if (highResolution)
@@ -683,11 +671,7 @@ void            SphereBspSceneNode::SphereBspRenderNode::render()
             }
             addTriangleCount(SphereLowRes * SphereLowRes * 2);
         }
-#ifdef GL_VERSION_1_2
         glDisable(GL_RESCALE_NORMAL);
-#else
-        glDisable(GL_NORMALIZE);
-#endif
     }
     else
     {

--- a/src/platform/SDL2Window.cxx
+++ b/src/platform/SDL2Window.cxx
@@ -214,6 +214,12 @@ bool SDLWindow::create(void)
         SDL_DestroyWindow(windowId);
     }
 
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+    SDL_GL_SetAttribute(
+        SDL_GL_CONTEXT_PROFILE_MASK,
+        SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
+
     // (re)create the window
     const Uint32 flags = SDL_WINDOW_OPENGL |
                          (fullScreen ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_RESIZABLE) |


### PR DESCRIPTION
Requesting openGL2.1

Removing all the check for things that are mandatory for that openGL version