### PR TITLE
Add bz_getSpawnPointWithin to API

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 BZFlag 2.4.19
 -------------
 
+* Add bz_getSpawnPointWithin to API - Vladimir Jimenez
 * Fix NetHandler compiler errors on Alpine Linux - Jim Melton
 * Significantly improve platform-dependent header imports - Jim Melton
 * Only perform texture conversion to internal format once

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -2008,6 +2008,7 @@ private:
 };
 
 BZF_API void bz_getRandomPoint ( bz_CustomZoneObject *obj, float *randomPos );
+BZF_API void bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float *randomPos );
 
 class bz_CustomMapObjectHandler
 {

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -33,6 +33,7 @@
 #include "CommandManager.h"
 #include "md5.h"
 #include "version.h"
+#include "DropGeometry.h"
 
 TimeKeeper synct = TimeKeeper::getCurrent();
 std::list<PendingChatMessages> pendingChatMessages;
@@ -3336,6 +3337,13 @@ BZF_API void bz_getRandomPoint ( bz_CustomZoneObject *obj, float *randomPos )
         randomPos[1] = (obj->radius * y) + pos[1];
         randomPos[2] = pos[2];
     }
+}
+
+BZF_API void bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float *randomPos )
+{
+    do {
+        bz_getRandomPoint(obj, randomPos);
+    } while (!DropGeometry::dropPlayer(randomPos, obj->zMin, obj->zMax));
 }
 
 BZF_API bool bz_registerCustomMapObject ( const char* object, bz_CustomMapObjectHandler *handler )

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -3341,8 +3341,24 @@ BZF_API void bz_getRandomPoint ( bz_CustomZoneObject *obj, float *randomPos )
 
 BZF_API void bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float *randomPos )
 {
+    TimeKeeper start = TimeKeeper::getCurrent();
+    int tries = 0;
+
     do {
+        if (tries >= 50)
+        {
+            tries = 0;
+
+            if (TimeKeeper::getCurrent() - start > BZDB.eval("_spawnMaxCompTime"))
+            {
+                randomPos[2] = obj->zMax;
+                logDebugMessage(1, "Warning: bz_getSpawnPointWithin ran out of time, just dropping the sucker in\n");
+                break;
+            }
+        }
+
         bz_getRandomPoint(obj, randomPos);
+        ++tries;
     } while (!DropGeometry::dropPlayer(randomPos, obj->zMin, obj->zMax));
 }
 


### PR DESCRIPTION
When I originally introduced `bz_getRandomPoint()` to the API, I didn't take into consideration that there may be obstacles in said zones. This is what `bz_getSpawnPointWithin()` is supposed to solve by using our `DropGeometry::dropPlayer()`.

~However, I don't have a fail-safe right now so this can potentially introduce an infinite loop if there are no safe locations. Should I use `_spawnMaxCompTime` to decide when to exit out like our spawn policies? What behavior should exist if this exits out?~

Or is there a better solution to this problem entirely?