### PR TITLE
Fix warnings on gcc-9.2

### DIFF
--- a/src/bzadmin/BZAdminClient.cxx
+++ b/src/bzadmin/BZAdminClient.cxx
@@ -47,11 +47,7 @@ BZAdminClient::BZAdminClient(BZAdminUI* bzInterface)
         {
         case ServerLink::BadVersion:
         {
-            static char versionError[] = "Incompatible server version XXXXXXXX";
-            // Flawfinder: ignore
-            strncpy(versionError + sizeof(versionError) - 8 - 1,
-                    sLink.getVersion(), 8);
-            std::cout << versionError;
+            std::cout << "Incompatible server version " << sLink.getVersion();
             break;
         }
         case ServerLink::Refused:

--- a/src/bzflag/CommandsImplementation.cxx
+++ b/src/bzflag/CommandsImplementation.cxx
@@ -660,7 +660,7 @@ bool LocalSetCommand::operator() (const char *commandLine)
 
 bool QuitCommand::operator() (const char *commandLine)
 {
-    char messageBuffer[MessageLen]; // send message
+    char messageBuffer[MessageLen + 1]; // send message
     strncpy(messageBuffer, commandLine, MessageLen);
     nboPackString(messageMessage + PlayerIdPLen, messageBuffer, MessageLen);
     serverLink->send(MsgMessage, sizeof(messageMessage), messageMessage);

--- a/src/bzflag/Player.cxx
+++ b/src/bzflag/Player.cxx
@@ -97,7 +97,7 @@ Player::Player(const PlayerId& _id, TeamColor _team,
     computedHits = 0;
 
     // set call sign
-    ::strncpy(callSign, name, CallSignLen);
+    ::strncpy(callSign, name, CallSignLen - 1);
     callSign[CallSignLen-1] = '\0';
 
     setMotto(_motto); // will be superseded by the server
@@ -168,7 +168,7 @@ static float rabbitRank (int wins, int losses)
 
 void Player::setMotto(const char* _motto)
 {
-    strncpy(motto, _motto, MottoLen);
+    strncpy(motto, _motto, MottoLen - 1);
     motto[MottoLen - 1] = '\0';   // ensure null termination
 }
 

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -1421,7 +1421,7 @@ static Player*      addPlayer(PlayerId id, const void* msg, int showMessage)
     msg = nboUnpackString (msg, motto, MottoLen);
 
     // Strip any ANSI color codes
-    strncpy (callsign, stripAnsiCodes (std::string (callsign)).c_str (), 32);
+    strncpy (callsign, stripAnsiCodes (std::string (callsign)).c_str (), 31);
 
     // id is slot, check if it's empty
     const int i = id;
@@ -4816,7 +4816,7 @@ static void     addRobots()
         }
         else
         {
-            snprintf(callsign, CallSignLen, "%.29s%2.2x", myTank->getCallSign(), j);
+            snprintf(callsign, CallSignLen, "%.29s%2.2x", myTank->getCallSign(), (short int)j);
             robots[j] = new RobotPlayer(robotServer[j]->getId(), callsign,
                                         robotServer[j], myTank->getMotto());
             robots[j]->setTeam(AutomaticTeam);
@@ -5392,9 +5392,8 @@ static void joinInternetGame()
         {
         case ServerLink::BadVersion:
         {
-            static char versionError[] = "Incompatible server version XXXXXXXX";
-            strncpy(versionError + strlen(versionError) - 8,
-                    serverLink->getVersion(), 8);
+            char versionError[37];
+            snprintf(versionError, sizeof(versionError), "Incompatible server version %s", serverLink->getVersion());
             HUDDialogStack::get()->setFailedMessage(versionError);
             break;
         }

--- a/src/bzfs/RecordReplay.cxx
+++ b/src/bzfs/RecordReplay.cxx
@@ -2067,9 +2067,9 @@ static bool saveHeader(int p, RRtime filetime, FILE *f)
     memset(&hdr, 0, sizeof(hdr));
     strncpy(hdr.callSign, callsign, sizeof(hdr.callSign));
     strncpy(hdr.motto, motto, sizeof(hdr.motto));
-    strncpy(hdr.ServerVersion, getServerVersion(), sizeof(hdr.ServerVersion));
-    strncpy(hdr.appVersion, getAppVersion(), sizeof(hdr.appVersion));
-    strncpy(hdr.realHash, hexDigest.c_str(), sizeof(hdr.realHash));
+    memcpy(hdr.ServerVersion, getServerVersion(), sizeof(hdr.ServerVersion));
+    strncpy(hdr.appVersion, getAppVersion(), sizeof(hdr.appVersion) - 1);
+    strncpy(hdr.realHash, hexDigest.c_str(), sizeof(hdr.realHash) - 1);
     packFlagTypes(flagsBuf, &hdr.flagsSize);
     hdr.flags = flagsBuf;
 

--- a/src/common/TimeKeeper.cxx
+++ b/src/common/TimeKeeper.cxx
@@ -182,7 +182,7 @@ const char *TimeKeeper::timestamp(void) // const
 
     strncpy(buffer, TextUtils::format("%04d-%02d-%02d %02d:%02d:%02d",
                                       now->tm_year, now->tm_mon, now->tm_mday,
-                                      now->tm_hour, now->tm_min, now->tm_sec).c_str(), 256);
+                                      now->tm_hour, now->tm_min, now->tm_sec).c_str(), 255);
     buffer[255] = '\0'; // safety
 
     return buffer;


### PR DESCRIPTION
Should avoid warning on strncpy from gcc-9.2
I have built it but not run yet
