### PR TITLE
Vertex buffers object handling

### DIFF
--- a/MSVC/build/geometry.vcxproj
+++ b/MSVC/build/geometry.vcxproj
@@ -431,6 +431,9 @@
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\src\geometry\VBO_Handler.cxx" />
+    <ClCompile Include="..\..\src\geometry\VBO_Manager.cxx" />
+    <ClCompile Include="..\..\src\geometry\VBO_Vertex.cxx" />
     <ClCompile Include="..\..\src\geometry\ViewFrustum.cxx">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -493,6 +496,9 @@
     <ClInclude Include="..\..\include\LaserSceneNode.h" />
     <ClInclude Include="..\..\include\MeshDrawMgr.h" />
     <ClInclude Include="..\..\include\MeshFragSceneNode.h" />
+    <ClInclude Include="..\..\include\VBO_Handler.h" />
+    <ClInclude Include="..\..\include\VBO_Manager.h" />
+    <ClInclude Include="..\..\include\VBO_Vertex.h" />
     <ClInclude Include="..\..\src\geometry\MeshRenderNode.h" />
     <ClInclude Include="..\..\include\MeshSceneNode.h" />
     <ClInclude Include="..\..\include\OpenGLGState.h" />

--- a/MSVC/build/geometry.vcxproj.filters
+++ b/MSVC/build/geometry.vcxproj.filters
@@ -124,6 +124,15 @@
     <ClCompile Include="..\..\src\geometry\ModelRender.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\geometry\VBO_Handler.cxx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\geometry\VBO_Manager.cxx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\geometry\VBO_Vertex.cxx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\BillboardSceneNode.h">
@@ -217,6 +226,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\geometry\model.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\VBO_Handler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\VBO_Manager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\VBO_Vertex.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/include/FlagSceneNode.h
+++ b/include/FlagSceneNode.h
@@ -54,8 +54,10 @@ protected:
         FlagRenderNode(const FlagSceneNode*);
         ~FlagRenderNode();
         void        render() override;
+        void renderShadow() override;
         const glm::vec3 getPosition() const override;
     private:
+        void render(bool shadow);
         const FlagSceneNode* sceneNode;
         int      waveReference;
     };

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -126,6 +126,9 @@ noinst_HEADERS =			\
 	TriWallSceneNode.h		\
 	ViewFrustum.h			\
 	VotingBooth.h			\
+	VBO_Handler.h			\
+	VBO_Manager.h			\
+	VBO_Vertex.h			\
 	WallObstacle.h			\
 	WallSceneNode.h			\
 	WallSceneNodeGenerator.h	\

--- a/include/MeshDrawInfo.h
+++ b/include/MeshDrawInfo.h
@@ -88,6 +88,7 @@ public:
     const afvec3* getVertices() const;
     const afvec3* getNormals() const;
     const afvec2* getTexcoords() const;
+    int getCornerCount() const;
 
     int getRadarCount() const;
     const DrawLod* getRadarLods() const;
@@ -205,6 +206,10 @@ inline const afvec3* MeshDrawInfo::getNormals() const
 inline const afvec2* MeshDrawInfo::getTexcoords() const
 {
     return texcoords;
+}
+inline int MeshDrawInfo::getCornerCount() const
+{
+    return cornerCount;
 }
 inline int MeshDrawInfo::getRadarCount() const
 {

--- a/include/MeshDrawMgr.h
+++ b/include/MeshDrawMgr.h
@@ -12,8 +12,8 @@
 
 #pragma once
 
-// 1st
-#include "common.h"
+// inherits from
+#include "VBO_Manager.h"
 
 // System headers
 #include <vector>
@@ -22,25 +22,19 @@
 #include "bzfgl.h"
 #include "MeshDrawInfo.h"
 
-class MeshDrawMgr
+class MeshDrawMgr : public VBOclient
 {
 public:
     MeshDrawMgr(const MeshDrawInfo* drawInfo);
     ~MeshDrawMgr();
 
     void executeSet(int lod, int set, bool useNormals, bool useTexcoords);
-    void executeSetGeometry(int lod, int set);
-
-private:
-    void rawExecuteCommands(int lod, int set);
-
-    void makeLists();
-    void freeLists();
-    static void initContext(void* data);
-    static void freeContext(void* data);
+    void initVBO() override;
 
 private:
     const MeshDrawInfo* drawInfo;
+
+    int vboArrayIndex; // this needs some explanation (or encapsulation in VBOclient)
 
     using LodList = std::vector<int>;
     std::vector<LodList> lodLists;

--- a/include/MeshFragSceneNode.h
+++ b/include/MeshFragSceneNode.h
@@ -61,27 +61,19 @@ protected:
         Geometry(MeshFragSceneNode &node);
         ~Geometry();
 
+        void initVBO() override;
+
         void init();
         void setStyle(int style);
         void render() override;
-        void renderRadar() override;
         void renderShadow() override;
         const glm::vec3 getPosition() const override;
 
     private:
-        void drawV() const; // draw with just vertices
-        void drawVT() const; // draw with texcoords
-        void drawVN() const; // draw with normals
-        void drawVTN() const; // draw with texcoords and normals
+        void renderVBO();
 
-        void initDisplayList();
-        void freeDisplayList();
-        static void initContext(void *data);
-        static void freeContext(void *data);
-
-    private:
         int style;
-        GLuint list;
+        int vboIndex;
         MeshFragSceneNode &sceneNode;
     };
 

--- a/include/RenderNode.h
+++ b/include/RenderNode.h
@@ -20,8 +20,8 @@
 
 #pragma once
 
-// Before everything
-#include "common.h"
+// Inherits from
+#include "VBO_Manager.h"
 
 // System headers
 #include <glm/fwd.hpp>
@@ -31,11 +31,10 @@
 #include "OpenGLGState.h"
 
 
-class RenderNode
+class RenderNode : public VBOclient
 {
 public:
     RenderNode() = default;
-    virtual ~RenderNode() = default;
 
     virtual void    render() = 0;
     virtual void    renderShadow();
@@ -96,7 +95,6 @@ public:
 private:
     struct Item
     {
-    public:
         using GStatePtr = OpenGLGState const *;
         RenderNode* node;
         GStatePtr   gstate;

--- a/include/VBO_Handler.h
+++ b/include/VBO_Handler.h
@@ -1,0 +1,80 @@
+/* bzflag
+ * Copyright (c) 2019-2019 Tim Riker
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef BZF_VBO_HANDLER_H
+#define BZF_VBO_HANDLER_H
+
+#include "common.h"
+
+// system interface headers
+#include <list>
+#include <string>
+
+// Manage the allocation of memory inside the GL buffers
+// You can allocate/deallocate memory from this class
+class VBO_Handler
+{
+public:
+    // Ctor with the size of the buffer to manage
+    VBO_Handler(int vboSize);
+    virtual ~VBO_Handler();
+
+    // Called to initialize/destroy the buffer
+    virtual void init() = 0;
+    virtual void destroy() = 0;
+    // Name of the Buffer (only for diagnostic)
+    virtual std::string vboName() = 0;
+
+    // This method allocate Vsize elements and return
+    // the index of the first element
+    // It will search in the free memory list a chunk big
+    // enough to contain the requested size and remove he chunk
+    // or resize it, from the free list.
+    // It will add in the allocate memory list the new chunk
+    int  vboAlloc(int Vsize);
+    // This method free the elements pointed by vboIndex
+    // the vboIndex should come from a previous vboAlloc
+    // This search in the allocate memory list the chuck that start
+    // at vboIndex. remore it from the allocate List and add
+    // to the free memeory list. It recompat that, in case
+    void vboFree(int vboIndex);
+
+protected:
+    // Size of the buffer (in terms of elements)
+    int  vboSize;
+
+private:
+    // Chunk of memory present in the buffer
+    struct MemElement
+    {
+        int vboIndex;
+        int Vsize;
+    };
+
+    // Free Memory List
+    // At the beginning it contains only a chunk of memory
+    // from 0 to vboSize
+    std::list<MemElement> freeVBOList;
+    // Allocalte Memory List
+    // At the beginning it is empty
+    std::list<MemElement> alloVBOList;
+};
+
+#endif
+
+// Local Variables: ***
+// mode: C++ ***
+// tab-width: 4 ***
+// c-basic-offset: 4 ***
+// indent-tabs-mode: nil ***
+// End: ***
+// ex: shiftwidth=4 tabstop=4

--- a/include/VBO_Manager.h
+++ b/include/VBO_Manager.h
@@ -1,0 +1,99 @@
+/* bzflag
+ * Copyright (c) 2019-2020 Tim Riker
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef BZF_VBO_MANAGER_H
+#define BZF_VBO_MANAGER_H
+
+// System headers
+#include <list>
+
+// Common headers
+#include "VBO_Handler.h"
+
+// An abstract class for a client that use GL buffers
+// the initVBO method will be called when it is time to (re)initialize
+// the GL buffers
+// It needs to register/unregister from the VBO_Manager to start/stop
+// this mechanism
+
+class VBOclient
+{
+public:
+    virtual ~VBOclient();
+
+    // will be called when GL buffers are (re)created
+    // All the static content of the GL buffer can be loaded here,
+    // but it will be lost when the GL context is recreated.
+    // No allocation should be undone here as the entire content
+    // of the GL buffer is declared automatically free
+    virtual void initVBO();
+};
+
+// A class to informs both
+// the clients (VBOclient) and
+// the GLbuffer owners (VBO_Handler)
+// about the reinizialization of the GL context
+// Could be a singleton
+class VBO_Manager
+{
+public:
+    VBO_Manager();
+    ~VBO_Manager();
+
+    // registration methods for (GL buffers) handlers (VBO_Handler)
+    // This class will call
+    // VBO_Handler::init() on context creation
+    // VBO_Handler::destroy on context deletion
+    void registerHandler(VBO_Handler *handler);
+    void unregisterHandler(VBO_Handler *handler);
+
+    // registration methods for client (VBOclient)
+    // This class will call
+    // VBOClient::initVBO() on context creation but
+    // after the GL buffers handlers are reset
+    void registerClient(VBOclient *client);
+    void unregisterClient(VBOclient *client);
+
+private:
+    // Those are callback for GL Context creation/free
+    // Called by OpenGLGState::
+    // data is going to be the VBO_Manager
+    // initContext will call VBO_Manager::initAll()
+    // freeContext will call VBO_Manager::destroyAll()
+    static void initContext(void* data);
+    static void freeContext(void* data);
+
+    // will init or reset all clients/handlers
+    void initAll();
+    void destroyAll();
+
+    std::list<VBO_Handler*> handlerList;
+    std::list<VBOclient*> clientList;
+
+    // This will trace if the context is ready or not
+    // It is used when a VBOclient register. The initVBO will be called,
+    // unless the context is not ready yet
+    static bool glContextReady;
+};
+
+extern VBO_Manager vboManager;
+
+#endif
+
+// Local Variables: ***
+// mode: C++ ***
+// tab-width: 4 ***
+// c-basic-offset: 4 ***
+// indent-tabs-mode: nil ***
+// End: ***
+// ex: shiftwidth=4 tabstop=4
+

--- a/include/VBO_Vertex.h
+++ b/include/VBO_Vertex.h
@@ -1,0 +1,163 @@
+/* bzflag
+ * Copyright (c) 2019-2019 Tim Riker
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef BZF_VBO_VERTEX_H
+#define BZF_VBO_VERTEX_H
+
+// inherits from
+#include "VBO_Handler.h"
+
+// system interface headers
+#include <list>
+#include <string>
+#include <vector>
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
+
+// common interface headers
+#include "bzfgl.h"
+
+// This class handle the vertex GL buffer and additional
+// texCoord/Normal/Color GL buffers
+// The size (in number of elements) is defined at creation time
+// Vertex Buffer is designed to have 3 coords
+// Normals the same
+// TexCoords 2 coords
+// Colors 4 coords
+class VBO_Vertex: public VBO_Handler
+{
+public:
+    // Ctor: Set the availability of the extra buffers and the size
+    VBO_Vertex(
+        bool handleTexture,
+        bool handleNormal,
+        bool handleColor,
+        int  vertexSize);
+    ~VBO_Vertex();
+
+    // Init will be called when a GL Context is ready
+    // It creates all the GL buffers requested,
+    void init() override;
+    // Destroy will delete the GL Buffers
+    void destroy() override;
+    // Name of the VBO
+    std::string vboName() override;
+
+    // These write the GL buffers at position index from an std::vector
+    void vertexData(int index, const std::vector<glm::vec3> vertices);
+    void textureData(int index, const std::vector<glm::vec2> textures);
+    void normalData(int index, const std::vector<glm::vec3> normals);
+    void colorData(int index, const std::vector<glm::vec4> colors);
+
+    // These are for the case the caller provides a bidinmensional array
+    void vertexData(int index, int size, const GLfloat vertices[][3]);
+    void textureData(int index, int size, const GLfloat textures[][2]);
+    void normalData(int index, int size, const GLfloat normals[][3]);
+    void colorData(int index, int size, const GLfloat colors[][4]);
+
+    // These are for the case the caller provides a pointer to the first element
+    void vertexData(int index, int size, const GLfloat *vertices);
+    void textureData(int index, int size, const GLfloat *textures);
+    void normalData(int index, int size, const GLfloat *normals);
+    void colorData(int index, int size, const GLfloat *colors);
+
+    // These are for the case the caller provides an array of glm::vec* elements
+    void vertexData(int index, int size, const glm::vec3 vertices[]);
+    void textureData(int index, int size, const glm::vec2 textures[]);
+    void normalData(int index, int size, const glm::vec3 normals[]);
+    void colorData(int index, int size, const glm::vec4 colors[]);
+
+    // This method bind all the buffers, to be ready for drawing
+    void enableArrays();
+    // This method will select which buffer should be enabled
+    // Vertex is always enabled
+    void enableArrays(bool texture, bool normal, bool color);
+    // This method will enable the vertex buffer only (used for shadows
+    void enableVertexOnly();
+
+private:
+    // These disable the usage of TexCoord/Normals/Colors,
+    // but do not unbind the related buffer
+    static void disableTextures();
+    static void disableNormals();
+    static void disableColors();
+
+    // The binded vertex/texture/normals/colors buffer
+    static GLuint actVerts;
+    static GLuint actTxcds;
+    static GLuint actNorms;
+    static GLuint actColrs;
+
+    // Taken from the ctor
+    bool handleTexture;
+    bool handleNormal;
+    bool handleColor;
+
+    // The GL buffers created from the class
+    // After enableArray these are copied in the static one
+    GLuint verts;
+    GLuint txcds;
+    GLuint norms;
+    GLuint colrs;
+
+    // Bind vertex Buffer
+    void enableVertex();
+    // Bind the relevant Buffer and enable its usage
+    void enableTextures();
+    void enableNormals();
+    void enableColors();
+
+    // mantain the status of the enabling of the buffers
+    static bool textureEnabled;
+    static bool normalEnabled;
+    static bool colorEnabled;
+};
+
+// This class is for the ELement (Indirect drawing)
+class VBO_Element: public VBO_Handler
+{
+public:
+    VBO_Element(int indexSize);
+    ~VBO_Element();
+
+    void init() override;
+    void destroy() override;
+    std::string vboName() override;
+
+    void elementData(
+        int index,
+        int size,
+        const GLuint element[]);
+
+private:
+    GLuint elems;
+};
+
+extern VBO_Vertex vboV;
+extern VBO_Vertex vboVC;
+extern VBO_Vertex vboVN;
+extern VBO_Vertex vboVT;
+extern VBO_Vertex vboVTN;
+extern VBO_Vertex vboVTC;
+extern VBO_Vertex vboVTNC;
+extern VBO_Element vboElement;
+
+#endif
+
+// Local Variables: ***
+// mode: C++ ***
+// tab-width: 4 ***
+// c-basic-offset: 4 ***
+// indent-tabs-mode: nil ***
+// End: ***
+// ex: shiftwidth=4 tabstop=4

--- a/src/bzflag/BackgroundRenderer.cxx
+++ b/src/bzflag/BackgroundRenderer.cxx
@@ -1240,10 +1240,6 @@ void BackgroundRenderer::drawGroundShadows(
     // disable color updates
     SceneNode::setColorOverride(true);
 
-    // disable the unused arrays
-    glDisableClientState(GL_NORMAL_ARRAY);
-    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-
     if (BZDBCache::stencilShadows)
     {
         OpenGLGState::resetState();
@@ -1287,10 +1283,6 @@ void BackgroundRenderer::drawGroundShadows(
     SceneNode::setColorOverride(false);
 
     OpenGLGState::resetState();
-
-    // re-enable the arrays
-    glEnableClientState(GL_NORMAL_ARRAY);
-    glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
     glPopMatrix();
 }

--- a/src/bzflag/defaultBZDB.cxx
+++ b/src/bzflag/defaultBZDB.cxx
@@ -131,8 +131,6 @@ DefaultDBItem defaultDBItems[] =
     // hidden graphics rendering params
     { "useDrawInfo",      "1",            true,   StateDatabase::ReadWrite,   NULL },
     { "f2bsort",          "1",            true,   StateDatabase::ReadWrite,   NULL },
-    { "meshLists",        "1",            true,   StateDatabase::ReadWrite,   NULL },
-    { "flagLists",        "0",            true,   StateDatabase::ReadWrite,   NULL },
     { "lightLists",       "0",            true,   StateDatabase::ReadWrite,   NULL },
     { "noMeshClusters",       "0",            true,   StateDatabase::ReadWrite,   NULL },
 

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -7408,8 +7408,6 @@ static void     playingLoop()
             sendRobotUpdates();
 #endif
 
-        FlagSceneNode::freeFlag();
-
         cURLManager::perform();
 
         // check if we are waiting for initial texture downloading
@@ -7474,6 +7472,8 @@ static void     playingLoop()
         doMessages();
 
     } // end main client loop
+
+    FlagSceneNode::freeFlag();
 }
 
 

--- a/src/geometry/Makefile.am
+++ b/src/geometry/Makefile.am
@@ -42,6 +42,9 @@ libGeometry_la_SOURCES  =		\
 	ViewFrustum.cxx			\
 	WavefrontOBJ.h			\
 	WavefrontOBJ.cxx		\
+	VBO_Handler.cxx			\
+	VBO_Manager.cxx			\
+	VBO_Vertex.cxx			\
 	WallSceneNode.cxx
 
 libGeometry_la_LIBADD =	\

--- a/src/geometry/MeshRenderNode.cxx
+++ b/src/geometry/MeshRenderNode.cxx
@@ -81,7 +81,7 @@ void OpaqueRenderNode::renderRadar()
 {
     glPushMatrix();
     glMultMatrixf(xformMatrix);
-    drawMgr->executeSetGeometry(lod, set);
+    drawMgr->executeSet(lod, set, false, false);
     glPopMatrix();
 
     addTriangleCount(triangles);
@@ -94,7 +94,7 @@ void OpaqueRenderNode::renderShadow()
 {
     glPushMatrix();
     glMultMatrixf(xformMatrix);
-    drawMgr->executeSetGeometry(lod, set);
+    drawMgr->executeSet(lod, set, false, false);
     glPopMatrix();
 
     addTriangleCount(triangles);

--- a/src/geometry/VBO_Handler.cxx
+++ b/src/geometry/VBO_Handler.cxx
@@ -1,0 +1,153 @@
+/* bzflag
+ * Copyright (c) 1993-2018 Tim Riker
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+// interface header
+#include "VBO_Handler.h"
+
+// System headers
+#include <iostream>
+#include <algorithm>
+#ifdef _WANT_BACKTRACE
+#include <execinfo.h>
+#endif
+
+#include "VBO_Manager.h"
+
+VBO_Handler::VBO_Handler(int vboSize_) :
+    vboSize(vboSize_)
+{
+    vboManager.registerHandler(this);
+    freeVBOList.push_back({0, vboSize});
+}
+
+VBO_Handler::~VBO_Handler()
+{
+    vboManager.unregisterHandler(this);
+}
+
+void trace_and_abort()
+{
+#ifdef _WANT_BACKTRACE
+    void *array[10];
+    size_t size;
+    char **strings;
+    size_t i;
+    size = backtrace (array, 10);
+    strings = backtrace_symbols (array, size);
+    printf ("Obtained %zd stack frames.\n", size);
+    for (i = 0; i < size; i++)
+        printf ("%s\n", strings[i]);
+    free (strings);
+#endif
+    abort();
+}
+
+int VBO_Handler::vboAlloc(int Vsize)
+{
+    MemElement memElement;
+
+    // First check if there is a chunk that fit precisely
+    auto it = std::find_if(freeVBOList.begin(), freeVBOList.end(),
+                           [&](auto& item)
+    {
+        return item.Vsize == Vsize;
+    });
+    if (it == freeVBOList.end())
+        // If not check if there is a chunk big enough
+        it = std::find_if(freeVBOList.begin(), freeVBOList.end(),
+                          [&](auto& item)
+    {
+        return item.Vsize > Vsize;
+    });
+    if (it == freeVBOList.end())
+    {
+        // Bad, not enough memory (or too fragmented)
+        std::cout << vboName() << " requested " << Vsize << " vertexes" << std::endl;
+        trace_and_abort ();
+    }
+
+    // Push a new element in the alloc list
+    memElement.Vsize    = Vsize;
+    memElement.vboIndex = it->vboIndex;
+    alloVBOList.push_back(memElement);
+
+    // Reduse the size of the old chunk
+    it->Vsize    -= Vsize;
+    it->vboIndex += Vsize;;
+    // If nothing more drop from the Free List
+    if (!it->Vsize)
+        freeVBOList.erase(it);
+
+    // return the address of the chunk
+    return memElement.vboIndex;
+}
+
+void VBO_Handler::vboFree(int vboIndex)
+{
+    MemElement memElement;
+
+    // Check if we allocated that index
+    auto it = std::find_if(alloVBOList.begin(), alloVBOList.end(),
+                           [&](auto& item)
+    {
+        return (item.vboIndex == vboIndex);
+    });
+
+    if (it == alloVBOList.end())
+    {
+        if (vboIndex < 0)
+            return;
+        // Bad, that index was never allocated
+        std::cout << vboName() << " deallocated " << vboIndex << " never allocated" << std::endl;
+        trace_and_abort ();
+    }
+
+    // Save the chunk and drop from the allocated list
+    memElement.vboIndex = vboIndex;
+    memElement.Vsize    = it->Vsize;
+    alloVBOList.erase(it);
+
+    // Check in the free list for a contiguous previous chunk
+    it = std::find_if(freeVBOList.begin(), freeVBOList.end(),
+                      [&](auto& item)
+    {
+        return (item.vboIndex + item.Vsize == memElement.vboIndex);
+    });
+    if (it != freeVBOList.end())
+    {
+        memElement.vboIndex = it->vboIndex;
+        memElement.Vsize   += it->Vsize;
+        freeVBOList.erase(it);
+    }
+
+    // Check in the free list for a contiguous successor chunk
+    it = std::find_if(freeVBOList.begin(), freeVBOList.end(),
+                      [&](auto& item)
+    {
+        return (item.vboIndex == memElement.vboIndex + memElement.Vsize);
+    });
+    if (it != freeVBOList.end())
+    {
+        memElement.Vsize   += it->Vsize;
+        freeVBOList.erase(it);
+    }
+    freeVBOList.push_back(memElement);
+}
+
+
+// Local Variables: ***
+// mode: C++ ***
+// tab-width: 4 ***
+// c-basic-offset: 4 ***
+// indent-tabs-mode: nil ***
+// End: ***
+// ex: shiftwidth=4 tabstop=4

--- a/src/geometry/VBO_Manager.cxx
+++ b/src/geometry/VBO_Manager.cxx
@@ -1,0 +1,95 @@
+/* bzflag
+ * Copyright (c) 2019-2019 Tim Riker
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+// interface header
+#include "VBO_Manager.h"
+
+// common implementation header
+#include "OpenGLGState.h"
+#include "VBO_Handler.h"
+
+VBOclient::~VBOclient()
+{
+}
+
+void VBOclient::initVBO()
+{
+}
+
+bool VBO_Manager::glContextReady = false;
+
+VBO_Manager::VBO_Manager ()
+{
+    OpenGLGState::registerContextInitializer(freeContext, initContext, this);
+}
+
+VBO_Manager::~VBO_Manager ()
+{
+    OpenGLGState::unregisterContextInitializer(freeContext, initContext, this);
+}
+
+void VBO_Manager::registerHandler(VBO_Handler *handler)
+{
+    handlerList.push_back(handler);
+}
+
+void VBO_Manager::unregisterHandler(VBO_Handler *handler)
+{
+    handlerList.remove(handler);
+}
+
+void VBO_Manager::registerClient(VBOclient *client)
+{
+    clientList.push_back(client);
+    if (glContextReady)
+        client->initVBO();
+}
+
+void VBO_Manager::unregisterClient(VBOclient *client)
+{
+    clientList.remove(client);
+}
+
+void VBO_Manager::initAll()
+{
+    glEnableClientState(GL_VERTEX_ARRAY);
+    for (auto handler : handlerList) handler->init();
+    for (auto client : clientList) client->initVBO();
+}
+
+void VBO_Manager::destroyAll()
+{
+    for (auto handler : handlerList) handler->destroy();
+}
+
+void VBO_Manager::initContext(void* data)
+{
+    glContextReady = true;
+    static_cast<VBO_Manager*>(data)->initAll();
+}
+
+void VBO_Manager::freeContext(void* data)
+{
+    glContextReady = false;
+    static_cast<VBO_Manager*>(data)->destroyAll();
+}
+
+VBO_Manager vboManager;
+
+
+// Local Variables: ***
+// mode: C++ ***
+// tab-width: 4 ***
+// c-basic-offset: 4 ***
+// indent-tabs-mode: nil ***
+// End: ***
+// ex: shiftwidth=4 tabstop=4

--- a/src/geometry/VBO_Vertex.cxx
+++ b/src/geometry/VBO_Vertex.cxx
@@ -1,0 +1,396 @@
+/* bzflag
+ * Copyright (c) 1993-2018 Tim Riker
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+// interface header
+#include "VBO_Vertex.h"
+
+bool VBO_Vertex::textureEnabled = false;
+bool VBO_Vertex::normalEnabled  = false;
+bool VBO_Vertex::colorEnabled   = false;
+GLuint VBO_Vertex::actVerts     = 0;
+GLuint VBO_Vertex::actNorms     = 0;
+GLuint VBO_Vertex::actTxcds     = 0;
+GLuint VBO_Vertex::actColrs     = 0;
+
+VBO_Vertex::VBO_Vertex(
+    bool handleTexture_,
+    bool handleNormal_,
+    bool handleColor_,
+    int vertexSize_) :
+    VBO_Handler(vertexSize_),
+    handleTexture(handleTexture_), handleNormal(handleNormal_),
+    handleColor(handleColor_)
+{
+}
+
+VBO_Vertex::~VBO_Vertex()
+{
+}
+
+void VBO_Vertex::init()
+{
+    glGenBuffers(1, &verts);
+    glBindBuffer(GL_ARRAY_BUFFER, verts);
+    glBufferData(
+        GL_ARRAY_BUFFER,
+        vboSize * sizeof(GLfloat[3]),
+        nullptr,
+        GL_DYNAMIC_DRAW);
+    if (handleTexture)
+    {
+        glGenBuffers(1, &txcds);
+        glBindBuffer(GL_ARRAY_BUFFER, txcds);
+        glBufferData(
+            GL_ARRAY_BUFFER,
+            vboSize * sizeof(GLfloat[2]),
+            nullptr,
+            GL_DYNAMIC_DRAW);
+    }
+    if (handleNormal)
+    {
+        glGenBuffers(1, &norms);
+        glBindBuffer(GL_ARRAY_BUFFER, norms);
+        glBufferData(
+            GL_ARRAY_BUFFER,
+            vboSize * sizeof(GLfloat[3]),
+            nullptr,
+            GL_DYNAMIC_DRAW);
+    }
+    if (handleColor)
+    {
+        glGenBuffers(1, &colrs);
+        glBindBuffer(GL_ARRAY_BUFFER, colrs);
+        glBufferData(
+            GL_ARRAY_BUFFER,
+            vboSize * sizeof(GLfloat[4]),
+            nullptr,
+            GL_DYNAMIC_DRAW);
+    }
+    enableVertexOnly();
+}
+
+void VBO_Vertex::destroy()
+{
+    enableVertexOnly();
+    glDeleteBuffers(1, &verts);
+    if (handleTexture)
+        glDeleteBuffers(1, &txcds);
+    if (handleNormal)
+        glDeleteBuffers(1, &norms);
+    if (handleColor)
+        glDeleteBuffers(1, &colrs);
+}
+
+std::string VBO_Vertex::vboName()
+{
+    std::string name = "V";
+    if (handleTexture)
+        name += "T";
+    if (handleNormal)
+        name += "N";
+    if (handleColor)
+        name += "C";
+    return name;
+}
+
+void VBO_Vertex::vertexData(
+    int index,
+    int size,
+    const GLfloat vertices[][3])
+{
+    vertexData(index, size, vertices[0]);
+}
+
+void VBO_Vertex::vertexData(int index, int size, const GLfloat *vertices)
+{
+    glBindBuffer(GL_ARRAY_BUFFER, verts);
+    glBufferSubData(
+        GL_ARRAY_BUFFER,
+        index * sizeof(GLfloat[3]),
+        size * sizeof(GLfloat[3]),
+        vertices);
+}
+
+void VBO_Vertex::vertexData(int index, int size, const glm::vec3 vertices[])
+{
+    vertexData(index, size, &vertices[0][0]);
+}
+
+void VBO_Vertex::vertexData(
+    int index,
+    const std::vector<glm::vec3> vertices)
+{
+    vertexData(index, vertices.size(), vertices.data());
+}
+
+void VBO_Vertex::textureData(
+    int index,
+    int size,
+    const GLfloat textures[][2])
+{
+    textureData(index, size, textures[0]);
+}
+
+void VBO_Vertex::textureData(int index, int size, const GLfloat *textures)
+{
+    if (!handleTexture)
+        return;
+    glBindBuffer(GL_ARRAY_BUFFER, txcds);
+    glBufferSubData(
+        GL_ARRAY_BUFFER,
+        index * sizeof(GLfloat[2]),
+        size * sizeof(GLfloat[2]),
+        textures);
+}
+
+void VBO_Vertex::textureData(int index, int size, const glm::vec2 textures[])
+{
+    textureData(index, size, &textures[0][0]);
+}
+
+void VBO_Vertex::textureData(
+    int index,
+    const std::vector<glm::vec2> textures)
+{
+    textureData(index, textures.size(), textures.data());
+}
+
+void VBO_Vertex::normalData(
+    int index,
+    int size,
+    const GLfloat normals[][3])
+{
+    normalData(index, size, normals[0]);
+}
+
+void VBO_Vertex::normalData(int index, int size, const GLfloat *normals)
+{
+    if (!handleNormal)
+        return;
+    glBindBuffer(GL_ARRAY_BUFFER, norms);
+    glBufferSubData(
+        GL_ARRAY_BUFFER,
+        index * sizeof(GLfloat[3]),
+        size * sizeof(GLfloat[3]),
+        normals);
+}
+
+void VBO_Vertex::normalData(int index, int size, const glm::vec3 normals[])
+{
+    normalData(index, size, &normals[0][0]);
+}
+
+void VBO_Vertex::normalData(
+    int index,
+    const std::vector<glm::vec3> normals)
+{
+    normalData(index, normals.size(), normals.data());
+}
+
+void VBO_Vertex::colorData(
+    int index,
+    int size,
+    const GLfloat colors[][4])
+{
+    colorData(index, size, colors[0]);
+}
+
+void VBO_Vertex::colorData(int index, int size, const GLfloat *colors)
+{
+    if (!handleColor)
+        return;
+    glBindBuffer(GL_ARRAY_BUFFER, colrs);
+    glBufferSubData(
+        GL_ARRAY_BUFFER,
+        index * sizeof(GLfloat[4]),
+        size * sizeof(GLfloat[4]),
+        colors);
+}
+
+void VBO_Vertex::colorData(int index, int size, const glm::vec4 colors[])
+{
+    colorData(index, size, &colors[0][0]);
+}
+
+void VBO_Vertex::colorData(
+    int index,
+    const std::vector<glm::vec4> colors)
+{
+    colorData(index, colors.size(), colors.data());
+}
+
+void VBO_Vertex::enableArrays(bool texture, bool normal, bool color)
+{
+    enableVertex();
+    if (texture)
+        enableTextures();
+    else
+        disableTextures();
+    if (normal)
+        enableNormals();
+    else
+        disableNormals();
+    if (color)
+        enableColors();
+    else
+        disableColors();
+}
+
+void VBO_Vertex::enableArrays()
+{
+    enableArrays(handleTexture, handleNormal, handleColor);
+}
+
+void VBO_Vertex::enableVertexOnly()
+{
+    enableVertex();
+    disableTextures();
+    disableNormals();
+    disableColors();
+}
+
+void VBO_Vertex::enableVertex()
+{
+    if (actVerts == verts)
+        return;
+    glBindBuffer(GL_ARRAY_BUFFER, verts);
+    glVertexPointer(3, GL_FLOAT, 0, 0);
+}
+
+void VBO_Vertex::disableTextures()
+{
+    if (textureEnabled)
+        glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+    textureEnabled = false;
+}
+
+void VBO_Vertex::enableTextures()
+{
+    if (!handleTexture)
+        return;
+    if (!textureEnabled)
+    {
+        glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+        textureEnabled = true;
+    }
+    if (actTxcds == txcds)
+        return;
+    glBindBuffer(GL_ARRAY_BUFFER, txcds);
+    glTexCoordPointer(2, GL_FLOAT, 0, 0);
+}
+
+void VBO_Vertex::disableNormals()
+{
+    if (normalEnabled)
+        glDisableClientState(GL_NORMAL_ARRAY);
+    normalEnabled = false;
+}
+
+void VBO_Vertex::enableNormals()
+{
+    if (!handleNormal)
+        return;
+    if (!normalEnabled)
+    {
+        glEnableClientState(GL_NORMAL_ARRAY);
+        normalEnabled = true;
+    }
+    if (actNorms == norms)
+        return;
+    glBindBuffer(GL_ARRAY_BUFFER, norms);
+    glNormalPointer(GL_FLOAT, 0, 0);
+}
+
+void VBO_Vertex::disableColors()
+{
+    if (colorEnabled)
+        glDisableClientState(GL_COLOR_ARRAY);
+    colorEnabled = false;
+}
+
+void VBO_Vertex::enableColors()
+{
+    if (!handleColor)
+        return;
+    if (!colorEnabled)
+    {
+        glEnableClientState(GL_COLOR_ARRAY);
+        colorEnabled = true;
+    }
+    if (actColrs == colrs)
+        return;
+    glBindBuffer(GL_ARRAY_BUFFER, colrs);
+    glColorPointer(4, GL_FLOAT, 0, 0);
+}
+
+VBO_Element::VBO_Element(int indexSize) :
+    VBO_Handler(indexSize)
+{
+}
+
+VBO_Element::~VBO_Element()
+{
+}
+
+void VBO_Element::init()
+{
+    if (vboSize)
+    {
+        glGenBuffers(1, &elems);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, elems);
+        glBufferData(
+            GL_ELEMENT_ARRAY_BUFFER,
+            vboSize * sizeof(GLuint),
+            NULL,
+            GL_DYNAMIC_DRAW);
+    }
+}
+
+void VBO_Element::destroy()
+{
+    if (vboSize)
+        glDeleteBuffers(1, &elems);
+}
+
+std::string VBO_Element::vboName()
+{
+    return "E";
+}
+
+void VBO_Element::elementData(
+    int index,
+    int size,
+    const GLuint element[])
+{
+    glBufferSubData(
+        GL_ELEMENT_ARRAY_BUFFER,
+        index * sizeof(GLuint),
+        size * sizeof(GLuint),
+        element);
+}
+
+VBO_Vertex vboV(false, false, false, 1 << 18);
+VBO_Vertex vboVC(false, false, true, 1 << 18);
+VBO_Vertex vboVN(false, true, false, 1 << 15);
+VBO_Vertex vboVT(true, false, false, 1 << 21);
+VBO_Vertex vboVTC(true, false, true, 1 << 4);
+VBO_Vertex vboVTN(true, true, false, 1 << 19);
+VBO_Vertex vboVTNC(true, true, true, 1 << 0);
+VBO_Element vboElement(1 << 15);
+
+// Local Variables: ***
+// mode: C++ ***
+// tab-width: 4 ***
+// c-basic-offset: 4 ***
+// indent-tabs-mode: nil ***
+// End: ***
+// ex: shiftwidth=4 tabstop=4

--- a/src/ogl/OpenGLGState.cxx
+++ b/src/ogl/OpenGLGState.cxx
@@ -1382,10 +1382,6 @@ void OpenGLGState::initGLState()
     glShadeModel(GL_FLAT);
     glDisable(GL_ALPHA_TEST);
     glCullFace(GL_BACK);
-    // all arrays are enabled by default
-    glEnableClientState(GL_VERTEX_ARRAY);
-    glEnableClientState(GL_NORMAL_ARRAY);
-    glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 }
 
 // utility to check if an OpenGL extension is supported on this system


### PR DESCRIPTION
A Class to handle vertex buffer object, together with Index inside the vertex buffer
Does not take into account Client Buffer, so in the commit the previous usage of Client Buffer is moved to use this class.
I limited the reserve of buffer space on the GPU by playing on most of the site. Maybe the lenght of this buffer should come from BZDB variables.
