### PR TITLE
Use teleporter names in OBJ export instead of a counter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 BZFlag 2.4.19
 -------------
 
+* Use teleporter names in /saveworld .obj exports - Vladimir Jimenez
 * Add bz_getSpawnPointWithin to API - Vladimir Jimenez
 * Fix NetHandler compiler errors on Alpine Linux - Jim Melton
 * Significantly improve platform-dependent header imports - Jim Melton

--- a/src/obstacle/Teleporter.cxx
+++ b/src/obstacle/Teleporter.cxx
@@ -654,7 +654,7 @@ void Teleporter::printOBJ(std::ostream& out, const std::string& UNUSED(indent)) 
         xtool.modifyNormal(norms[i]);
 
     out << "# OBJ - start tele" << std::endl;
-    out << "o bztele_" << getObjCounter() << std::endl;
+    out << "o bztele_" << name << std::endl;
 
     for (i = 0; i < 8; i++)
     {
@@ -690,8 +690,6 @@ void Teleporter::printOBJ(std::ostream& out, const std::string& UNUSED(indent)) 
     out << "f -6/-4/-4 -5/-3/-4 -1/-2/-4 -2/-1/-4" << std::endl;
 
     out << std::endl;
-
-    incObjCounter();
 
     return;
 }


### PR DESCRIPTION
Turns out, teleporter names are kinda useful for reference

Fixes #233 