### PR TITLE
SDL2: Only create the window once

### DIFF
--- a/src/bzflag/MainWindow.cxx
+++ b/src/bzflag/MainWindow.cxx
@@ -277,10 +277,9 @@ void MainWindow::setProjectionRadar(int x, int y, int w, int h, float radarRange
 
 void            MainWindow::resize()
 {
-    window->getSize(trueWidth, trueHeight);
-    window->makeCurrent();
     if (!window->create())
         faulting = true;
+    window->getSize(trueWidth, trueHeight);
     setQuadrant(quadrant);
 }
 

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -1092,10 +1092,7 @@ static void     doEvent(BzfDisplay *disply)
 
     case BzfEvent::Resize:
         if (mainWindow->getWidth() != event.resize.width || mainWindow->getHeight() != event.resize.height)
-        {
-            mainWindow->getWindow()->setSize(event.resize.width, event.resize.height);
             mainWindow->getWindow()->callResizeCallbacks();
-        }
         break;
 
     case BzfEvent::Map:


### PR DESCRIPTION
This changes SDL2Window so that it only creates a window once.  It initially creates a window at the base size (640x480 or what was provided by the -window argument).  If the game is to be run fullscreen, it then changes to fullscreen.  Window size or resolution changes and switching between fullscreen and windowed merely changes the size and properties of the existing window instead of destroying and recreating the window.

This is similar to #228 but takes it further by never recreating the window.  Additionally, by creating the initial window at a lower resolution of 640x480, it works around the SDL2 multi-monitor issue in #201, assuming that there's at least a usable area of 640x480 (plus the size of the window decorations) on the primary display.

This likely breaks non-SDL2 platform code as I did adjust a couple other files.  I have tested this mostly on Linux.  I have not tested on macOS or with SDL1 or native Linux platform code.

I ran a brief test on Windows and changing the fullscreen resolution is broken, so I'll need to look into that some more.  Specifically, when I had two 2560x1440 displays, was running fullscreen, and tried to change to 1920x1080, it started rendering on the secondary display with an old snapshot of the menu stuck on the primary display.