### PR TITLE
Rewrite Frustum using glm

### DIFF
--- a/include/Frustum.h
+++ b/include/Frustum.h
@@ -17,7 +17,14 @@
 #ifndef BZF_FRUSTUM_H
 #define BZF_FRUSTUM_H
 
+// Before everything
 #include "common.h"
+
+// System headers
+#include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
+#include <glm/mat4x4.hpp>
+#include <glm/gtc/type_ptr.hpp>
 
 // FIXME -- will need a means for off center projections for
 // looking through teleporters
@@ -28,73 +35,69 @@ public:
     Frustum();
     ~Frustum();
 
-    const float*    getEye() const;
-    const float*    getDirection() const;
-    const float*    getUp() const;
-    const float*    getRight() const;
-    const float*    getSide(int index) const;
+    const glm::vec3 &getEye() const;
+    const glm::vec3 getDirection() const;
+    const glm::vec4 &getViewPlane() const;
+    const glm::vec3 &getUp() const;
+    const glm::vec4 &getSide(int index) const;
     int         getPlaneCount() const;
-    const float*    getFarCorner(int index) const;
-    float       getTilt() const; // degrees
-    float       getRotation() const; // degrees
-    float       getNear() const;
-    float       getFar() const;
-    const float*    getViewMatrix() const;
+    const glm::mat4 &getViewMatrix() const;
     float       getFOVx() const;
     float       getFOVy() const;
-    const float*    getProjectionMatrix() const;
-    float       getEyeDepth(const float*) const;
+    const glm::mat4 &getProjectionMatrix() const;
     float       getAreaFactor() const;
 
-    void        setView(const float* eye, const float* target);
+    void        setView(const glm::vec3 &eye, const glm::vec3 &target);
     void        setProjection(float fov,
                               float m_near, float m_far, float m_deep_far,
                               int width, int height, int viewHeight);
     void        setOffset(float eyeOffset, float focalPlane);
     void        setFarPlaneCull(bool useCulling);
     void        flipVertical();
-    void        flipHorizontal();
 
     // used for radar culling
     void        setOrthoPlanes(const Frustum& view,
                                float width, float breadth);
 
 protected:
-    void        makePlane(const float* v1, const float* v2, int);
-
-protected:
-    float       eye[3];
-    float       target[3];
-    float       right[3], up[3];
-    float       plane[6][4];        // pointing in
-    int         planeCount;
-    float       farCorner[4][3];
-    float       tilt;
-    float       rotation;
-    float       viewMatrix[16];
-    float       billboardMatrix[16];
+    glm::vec3   eye;
+    glm::mat4   viewMatrix;
+    glm::mat4   billboardMatrix;
+    glm::mat4   projectionMatrix;
+    glm::mat4   deepProjectionMatrix;
     float       m_near, m_far;
     float       fovx, fovy;
     float       areaFactor;
-    float       projectionMatrix[16];
-    float       deepProjectionMatrix[16];
+
+private:
+    void        makePlane(const glm::vec3 &v1, const glm::vec3 &v2, int);
+
+    glm::vec3   target;
+    glm::vec3   up;
+    glm::vec4   plane[6];        // pointing in
+    int         planeCount;
 };
 
 //
 // Frustum
 //
 
-inline const float* Frustum::getEye() const
+inline const glm::vec3 &Frustum::getEye() const
 {
     return eye;
 }
 
-inline const float* Frustum::getDirection() const
+inline const glm::vec3 Frustum::getDirection() const
+{
+    return glm::vec3(plane[0]);
+}
+
+inline const glm::vec4 &Frustum::getViewPlane() const
 {
     return plane[0];
 }
 
-inline const float* Frustum::getSide(int index) const
+inline const glm::vec4 &Frustum::getSide(int index) const
 {
     return plane[index];
 }
@@ -104,39 +107,9 @@ inline int      Frustum::getPlaneCount() const
     return planeCount;
 }
 
-inline const float* Frustum::getFarCorner(int index) const
-{
-    return farCorner[index];
-}
-
-inline float        Frustum::getTilt() const
-{
-    return tilt;
-}
-
-inline float        Frustum::getRotation() const
-{
-    return rotation;
-}
-
-inline const float* Frustum::getUp() const
+inline const glm::vec3 &Frustum::getUp() const
 {
     return up;
-}
-
-inline const float* Frustum::getRight() const
-{
-    return right;
-}
-
-inline float        Frustum::getNear() const
-{
-    return m_near;
-}
-
-inline float        Frustum::getFar() const
-{
-    return m_far;
 }
 
 inline float        Frustum::getFOVx() const
@@ -149,12 +122,12 @@ inline float        Frustum::getFOVy() const
     return fovy;
 }
 
-inline const float* Frustum::getViewMatrix() const
+inline const glm::mat4 &Frustum::getViewMatrix() const
 {
     return viewMatrix;
 }
 
-inline const float* Frustum::getProjectionMatrix() const
+inline const glm::mat4 &Frustum::getProjectionMatrix() const
 {
     return projectionMatrix;
 }

--- a/include/RenderNode.h
+++ b/include/RenderNode.h
@@ -21,7 +21,13 @@
 #ifndef BZF_RENDER_NODE_H
 #define BZF_RENDER_NODE_H
 
+// Before everything
 #include "common.h"
+
+// System headers
+#include <glm/vec3.hpp>
+
+// Global headers
 #include "OpenGLGState.h"
 
 
@@ -107,6 +113,7 @@ public:
     void        append(RenderNode*, const OpenGLGState*, float depth);
     void        render() const;
 
+    void        sort(const glm::vec3 &eye);
     void        sort(const GLfloat* eye);
 
     // public for the qsort() comparison function

--- a/include/SceneNode.h
+++ b/include/SceneNode.h
@@ -31,6 +31,7 @@
 
 // System headers
 #include <vector>
+#include <glm/vec3.hpp>
 
 // Common headers
 #include "bzfgl.h"
@@ -70,6 +71,7 @@ public:
     const GLfloat*      getPlane() const;
     const GLfloat*      getPlaneRaw() const;
     virtual GLfloat getDistance(const GLfloat* eye) const;
+    virtual GLfloat getDistance(const glm::vec3 &eye) const;
 
     virtual bool    inAxisBox (const Extents& exts) const;
 

--- a/src/bzflag/BackgroundRenderer.cxx
+++ b/src/bzflag/BackgroundRenderer.cxx
@@ -1187,7 +1187,7 @@ void BackgroundRenderer::drawGroundCentered()
 void BackgroundRenderer::drawGroundGrid(
     SceneRenderer& renderer)
 {
-    const GLfloat* pos = renderer.getViewFrustum().getEye();
+    const auto pos = renderer.getViewFrustum().getEye();
     const GLfloat xhalf = gridSpacing * (gridCount + floorf(pos[2] / 4.0f));
     const GLfloat yhalf = gridSpacing * (gridCount + floorf(pos[2] / 4.0f));
     const GLfloat x0 = floorf(pos[0] / gridSpacing) * gridSpacing;

--- a/src/bzflag/HUDRenderer.cxx
+++ b/src/bzflag/HUDRenderer.cxx
@@ -1097,8 +1097,8 @@ void            HUDRenderer::renderTankLabels(SceneRenderer& renderer)
                     window.getOriginX(), window.getOriginY(),
                     window.getWidth(), window.getHeight()
                 );
-    const GLfloat *projf = renderer.getViewFrustum().getProjectionMatrix();
-    const GLfloat *modelf = renderer.getViewFrustum().getViewMatrix();
+    const auto projf  = renderer.getViewFrustum().getProjectionMatrix();
+    const auto modelf = renderer.getViewFrustum().getViewMatrix();
 
     for (int i = 0; i < curMaxPlayers; i++)
     {
@@ -1109,8 +1109,8 @@ void            HUDRenderer::renderTankLabels(SceneRenderer& renderer)
             hudSColor3fv(Team::getRadarColor(pl->getTeam()));
             auto p = glm::project(
                          glm::make_vec3(pl->getPosition()),
-                         glm::make_mat4(modelf),
-                         glm::make_mat4(projf),
+                         modelf,
+                         projf,
                          view);
             if (p.z >= 0.0 && p.z <= 1.0)
             {
@@ -1228,11 +1228,11 @@ void            HUDRenderer::renderTimes(void)
     }
 }
 
-void HUDRenderer::saveMatrixes(const float *mm, const float *pm )
+void HUDRenderer::saveMatrixes(const glm::mat4 &mm, const glm::mat4 &pm)
 {
     // ssave off the stuff before we reset it
-    modelMatrix = glm::make_mat4(mm);
-    projMatrix  = glm::make_mat4(pm);
+    modelMatrix = mm;
+    projMatrix  = pm;
     glGetIntegerv(GL_VIEWPORT,glm::value_ptr(viewport));
 }
 

--- a/src/bzflag/HUDRenderer.h
+++ b/src/bzflag/HUDRenderer.h
@@ -116,7 +116,7 @@ public:
     void      AddLockOnMarker(const glm::vec3 &pos, std::string name,
                               bool friendly = false, float zShift = 0.0f);
 
-    void      saveMatrixes(const float* mm, const float* pm);
+    void      saveMatrixes(const glm::mat4 &mm, const glm::mat4 &pm);
     void      setDim(bool);
 
     bool      getComposing() const;

--- a/src/game/Frustum.cxx
+++ b/src/game/Frustum.cxx
@@ -10,28 +10,18 @@
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "common.h"
-#include <math.h>
-#include <string.h>
+// Interface
 #include "Frustum.h"
 
+// System headers
+#include <math.h>
+#include <string.h>
+#include <glm/gtc/matrix_access.hpp>
 
-Frustum::Frustum()
+Frustum::Frustum(): viewMatrix(1.0f), billboardMatrix(1.0f), projectionMatrix(1.0f), deepProjectionMatrix(1.0f)
 {
-    static float defaultEye[3] = { 0.0, 0.0, 0.0 };
-    static float defaultTarget[3] = { 0.0, 1.0, 0.0 };
-    static float identity[16] = { 1.0, 0.0, 0.0, 0.0,
-                                  0.0, 1.0, 0.0, 0.0,
-                                  0.0, 0.0, 1.0, 0.0,
-                                  0.0, 0.0, 0.0, 1.0
-                                };
-
-    // initialize view and projection matrices to identity
-    ::memcpy(viewMatrix, identity, sizeof(viewMatrix));
-    ::memcpy(billboardMatrix, identity, sizeof(billboardMatrix));
-    ::memcpy(projectionMatrix, identity, sizeof(projectionMatrix));
-    ::memcpy(deepProjectionMatrix, identity, sizeof(deepProjectionMatrix));
-
+    auto defaultEye = glm::vec3(0);
+    auto defaultTarget = glm::vec3(0, 1, 0);
     setProjection((float)(M_PI/4.0), 1.0f, 100.0f, 1000.0f, 1, 1, 1);
     setView(defaultEye, defaultTarget);
 }
@@ -43,128 +33,49 @@ Frustum::~Frustum()
 }
 
 
-float Frustum::getEyeDepth(const float* p) const
-{
-    return viewMatrix[2] * p[0] + viewMatrix[6] * p[1] +
-           viewMatrix[10] * p[2] + viewMatrix[14];
-}
-
-
-void Frustum::setView(const float* _eye, const float* _target)
+void Frustum::setView(const glm::vec3 &_eye, const glm::vec3 &_target)
 {
     // set eye and target points
-    eye[0] = _eye[0];
-    eye[1] = _eye[1];
-    eye[2] = _eye[2];
-    target[0] = _target[0];
-    target[1] = _target[1];
-    target[2] = _target[2];
-
-    // compute forward vector and normalize
-    plane[0][0] = target[0] - eye[0];
-    plane[0][1] = target[1] - eye[1];
-    plane[0][2] = target[2] - eye[2];
-    float d = 1.0f / sqrtf(plane[0][0] * plane[0][0] +
-                           plane[0][1] * plane[0][1] +
-                           plane[0][2] * plane[0][2]);
-    plane[0][0] *= d;
-    plane[0][1] *= d;
-    plane[0][2] *= d;
-
-    // compute left vector (by crossing forward with
-    // world-up [0 0 1]T and normalizing)
-    right[0] =  plane[0][1];
-    right[1] = -plane[0][0];
-    d = 1.0f / hypotf(right[0], right[1]);
-    right[0] *= d;
-    right[1] *= d;
-    right[2] = 0.0f;
-
-    // compute local up vector (by crossing right and forward,
-    // normalization unnecessary)
-    up[0] =  right[1] * plane[0][2];
-    up[1] = -right[0] * plane[0][2];
-    up[2] =  right[0] * plane[0][1] - right[1] * plane[0][0];
+    eye = _eye;
+    target = _target;
 
     // build view matrix, including a transformation bringing
     // world up [0 0 1 0]T to eye up [0 1 0 0]T, world north
     // [0 1 0 0]T to eye forward [0 0 -1 0]T.
-    viewMatrix[0] = right[0];
-    viewMatrix[4] = right[1];
-    viewMatrix[8] = 0.0f;
+    viewMatrix = glm::lookAt(eye, target, glm::vec3(0, 0, 1));
+    // left vector
+    auto right =  glm::vec3(glm::row(viewMatrix, 0));
+    // local up vector
+    up         =  glm::vec3(glm::row(viewMatrix, 1));
+    // forward vector normalized
+    auto z     = -glm::vec3(glm::row(viewMatrix, 2));
 
-    viewMatrix[1] = up[0];
-    viewMatrix[5] = up[1];
-    viewMatrix[9] = up[2];
-
-    viewMatrix[2] =  -plane[0][0];
-    viewMatrix[6] =  -plane[0][1];
-    viewMatrix[10] = -plane[0][2];
-
-    viewMatrix[12] = -(viewMatrix[0] * eye[0] +
-                       viewMatrix[4] * eye[1] +
-                       viewMatrix[8] * eye[2]);
-    viewMatrix[13] = -(viewMatrix[1] * eye[0] +
-                       viewMatrix[5] * eye[1] +
-                       viewMatrix[9] * eye[2]);
-    viewMatrix[14] = -(viewMatrix[2] * eye[0] +
-                       viewMatrix[6] * eye[1] +
-                       viewMatrix[10] * eye[2]);
 
     // build billboard matrix.  billboard matrix performs rotation
     // so that polygons drawn in the xy plane face the camera.
-    billboardMatrix[0] = viewMatrix[0];
-    billboardMatrix[1] = viewMatrix[4];
-    billboardMatrix[2] = viewMatrix[8];
-    billboardMatrix[4] = viewMatrix[1];
-    billboardMatrix[5] = viewMatrix[5];
-    billboardMatrix[6] = viewMatrix[9];
-    billboardMatrix[8] = viewMatrix[2];
-    billboardMatrix[9] = viewMatrix[6];
-    billboardMatrix[10] = viewMatrix[10];
+    billboardMatrix = glm::transpose(viewMatrix);
+    billboardMatrix[0][3] = 0;
+    billboardMatrix[1][3] = 0;
+    billboardMatrix[2][3] = 0;
 
     // compute vectors of frustum edges
-    const float xs = fabsf(1.0f / projectionMatrix[0]);
-    const float ys = fabsf(1.0f / projectionMatrix[5]);
-    float edge[4][3];
-    edge[0][0] = plane[0][0] - xs * right[0] - ys * up[0];
-    edge[0][1] = plane[0][1] - xs * right[1] - ys * up[1];
-    edge[0][2] = plane[0][2] - xs * right[2] - ys * up[2];
-    edge[1][0] = plane[0][0] + xs * right[0] - ys * up[0];
-    edge[1][1] = plane[0][1] + xs * right[1] - ys * up[1];
-    edge[1][2] = plane[0][2] + xs * right[2] - ys * up[2];
-    edge[2][0] = plane[0][0] + xs * right[0] + ys * up[0];
-    edge[2][1] = plane[0][1] + xs * right[1] + ys * up[1];
-    edge[2][2] = plane[0][2] + xs * right[2] + ys * up[2];
-    edge[3][0] = plane[0][0] - xs * right[0] + ys * up[0];
-    edge[3][1] = plane[0][1] - xs * right[1] + ys * up[1];
-    edge[3][2] = plane[0][2] - xs * right[2] + ys * up[2];
+    const float xs = fabsf(1.0f / projectionMatrix[0][0]);
+    const float ys = fabsf(1.0f / projectionMatrix[1][1]);
+    glm::vec3 edge[4];
+    edge[0] = z - xs * right - ys * up;
+    edge[1] = z + xs * right - ys * up;
+    edge[2] = z + xs * right + ys * up;
+    edge[3] = z - xs * right + ys * up;
 
     // make frustum planes
-    plane[0][3] = -(eye[0] * plane[0][0] + eye[1] * plane[0][1] +
-                    eye[2] * plane[0][2] + m_near);
+    plane[0] = glm::vec4(z, -glm::dot(eye, z) - m_near);
     makePlane(edge[0], edge[3], 1);
     makePlane(edge[2], edge[1], 2);
     makePlane(edge[1], edge[0], 3);
     makePlane(edge[3], edge[2], 4);
 
-    plane[5][0] = -plane[0][0];
-    plane[5][1] = -plane[0][1];
-    plane[5][2] = -plane[0][2];
-    plane[5][3] = -plane[0][3] + m_far;
-
-    // make far corners
-    for (int i = 0; i < 4; i++)
-    {
-        farCorner[i][0] = eye[0] + m_far * edge[i][0];
-        farCorner[i][1] = eye[1] + m_far * edge[i][1];
-        farCorner[i][2] = eye[2] + m_far * edge[i][2];
-    }
-
-    // setup tilt and angle
-    const float* dir = plane[0];
-    tilt = RAD2DEGf * atan2f(dir[2], 1.0f);
-    rotation = RAD2DEGf * atan2f(dir[1], dir[2]);
+    plane[5]     = -plane[0];
+    plane[5][3] += m_far;
 }
 
 
@@ -193,28 +104,28 @@ void Frustum::setProjection(float fov,
     // compute projectionMatrix
     const float s = 1.0f / tanf(fov / 2.0f);
     const float fracHeight = 1.0f - float(viewHeight) / float(height);
-    projectionMatrix[0] = s;
-    projectionMatrix[5] = (1.0f - fracHeight) * s * float(width) / float(viewHeight);
-    projectionMatrix[8] = 0.0f;
-    projectionMatrix[9] = -fracHeight;
-    projectionMatrix[10] = -(m_far + m_near) / (m_far - m_near);
-    projectionMatrix[11] = -1.0f;
-    projectionMatrix[12] = 0.0f;
-    projectionMatrix[14] = -2.0f * m_far * m_near / (m_far - m_near);
-    projectionMatrix[15] = 0.0f;
+    projectionMatrix[0][0] = s;
+    projectionMatrix[1][1] = (1.0f - fracHeight) * s * float(width) / float(viewHeight);
+    projectionMatrix[2][0] = 0.0f;
+    projectionMatrix[2][1] = -fracHeight;
+    projectionMatrix[2][2] = -(m_far + m_near) / (m_far - m_near);
+    projectionMatrix[2][3] = -1.0f;
+    projectionMatrix[3][0] = 0.0f;
+    projectionMatrix[3][2] = -2.0f * m_far * m_near / (m_far - m_near);
+    projectionMatrix[3][3] = 0.0f;
 
-    deepProjectionMatrix[0] = projectionMatrix[0];
-    deepProjectionMatrix[5] = projectionMatrix[5];
-    deepProjectionMatrix[8] = projectionMatrix[8];
-    deepProjectionMatrix[9] = projectionMatrix[9];
-    deepProjectionMatrix[11] = projectionMatrix[11];
-    deepProjectionMatrix[12] = projectionMatrix[12];
-    deepProjectionMatrix[15] = projectionMatrix[15];
-    deepProjectionMatrix[10] = -(m_deep_far + m_near) / (m_deep_far - m_near);
-    deepProjectionMatrix[14] = -2.0f * m_deep_far * m_near / (m_deep_far - m_near);
+    deepProjectionMatrix[0][0] = projectionMatrix[0][0];
+    deepProjectionMatrix[1][1] = projectionMatrix[1][1];
+    deepProjectionMatrix[2][0] = projectionMatrix[2][0];
+    deepProjectionMatrix[2][1] = projectionMatrix[2][1];
+    deepProjectionMatrix[2][3] = projectionMatrix[2][3];
+    deepProjectionMatrix[3][0] = projectionMatrix[3][0];
+    deepProjectionMatrix[3][3] = projectionMatrix[3][3];
+    deepProjectionMatrix[2][2] = -(m_deep_far + m_near) / (m_deep_far - m_near);
+    deepProjectionMatrix[3][2] = -2.0f * m_deep_far * m_near / (m_deep_far - m_near);
 
     // get field of view in y direction
-    fovy = 2.0f * atanf(1.0f / projectionMatrix[5]);
+    fovy = 2.0f * atanf(1.0f / projectionMatrix[1][1]);
 
     // compute areaFactor
     areaFactor = 0.25f * s * float(height);
@@ -224,26 +135,18 @@ void Frustum::setProjection(float fov,
 
 void Frustum::setOffset(float eyeOffset, float focalPlane)
 {
-    projectionMatrix[12] = 0.5f * eyeOffset * projectionMatrix[0];
-    projectionMatrix[8] = projectionMatrix[12] / focalPlane;
-    deepProjectionMatrix[8] = projectionMatrix[8];
-    deepProjectionMatrix[12] = projectionMatrix[12];
+    projectionMatrix[3][0] = 0.5f * eyeOffset * projectionMatrix[0][0];
+    projectionMatrix[2][0] = projectionMatrix[3][0] / focalPlane;
+    deepProjectionMatrix[2][0] = projectionMatrix[2][0];
+    deepProjectionMatrix[3][0] = projectionMatrix[3][0];
 }
 
 
-void Frustum::makePlane(const float* v1, const float* v2, int index)
+void Frustum::makePlane(const glm::vec3 &v1, const glm::vec3 &v2, int index)
 {
     // get normal by crossing v1 and v2 and normalizing
-    float n[3];
-    n[0] = v1[1] * v2[2] - v1[2] * v2[1];
-    n[1] = v1[2] * v2[0] - v1[0] * v2[2];
-    n[2] = v1[0] * v2[1] - v1[1] * v2[0];
-    float d = 1.0f / sqrtf(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
-    plane[index][0] = d * n[0];
-    plane[index][1] = d * n[1];
-    plane[index][2] = d * n[2];
-    plane[index][3] = -(eye[0] * plane[index][0] + eye[1] * plane[index][1] +
-                        eye[2] * plane[index][2]);
+    auto n = glm::normalize(glm::cross(v1, v2));
+    plane[index] = glm::vec4(n, -glm::dot(eye, n));
 }
 
 
@@ -254,20 +157,9 @@ void Frustum::flipVertical()
     eye[2] = -eye[2];
     target[2] = -target[2];
     setView(eye, target);
-    projectionMatrix[5] = -projectionMatrix[5];
-    deepProjectionMatrix[5] = -deepProjectionMatrix[5];
+    projectionMatrix[1][1] = -projectionMatrix[1][1];
+    deepProjectionMatrix[1][1] = -deepProjectionMatrix[1][1];
 
-    return;
-}
-
-
-void Frustum::flipHorizontal()
-{
-    eye[0] = -eye[0];
-    target[0] = -target[0];
-    setView(eye, target);
-    projectionMatrix[0] = -projectionMatrix[0];
-    deepProjectionMatrix[0] = -deepProjectionMatrix[0];
     return;
 }
 
@@ -276,54 +168,23 @@ void Frustum::flipHorizontal()
 void Frustum::setOrthoPlanes(const Frustum& view, float width, float breadth)
 {
     // setup the eye, and the clipping planes
-    memcpy(eye, view.getEye(), sizeof(float[3]));
+    eye = glm::make_vec3(view.getEye());
 
-    float front[2], left[2];
-    const float* dir = view.getDirection();
-    float len = (dir[0] * dir[0]) + (dir[1] * dir[1]);
-    if (len != 0)
-    {
-        len = 1.0f / sqrtf(len);
-        front[0] = dir[0] * len;
-        front[1] = dir[1] * len;
-    }
-    else
-    {
-        front[0] = 1.0f;
-        front[1] = 0.0f;
-    }
+    const auto dir = view.getDirection();
+    auto front = glm::vec3(1, 0, 0);
+    if (dir.x || dir.y)
+        front = glm::normalize(glm::vec3(dir.x, dir.y, 0));
 
-    left[0] = -front[1];
-    left[1] = +front[0];
+    auto left = glm::cross(glm::vec3(0, 0, 1), front);
 
-    plane[1][0] = +left[0];
-    plane[1][1] = +left[1];
-    plane[1][3] = -((eye[0] * plane[1][0]) + (eye[1] * plane[1][1])) + width;
-
-    plane[2][0] = -left[0];
-    plane[2][1] = -left[1];
-    plane[2][3] = -((eye[0] * plane[2][0]) + (eye[1] * plane[2][1])) + width;
-
-    plane[3][0] = +front[0];
-    plane[3][1] = +front[1];
-    plane[3][3] = -((eye[0] * plane[3][0]) + (eye[1] * plane[3][1])) + breadth;
-
-    plane[4][0] = -front[0];
-    plane[4][1] = -front[1];
-    plane[4][3] = -((eye[0] * plane[4][0]) + (eye[1] * plane[4][1])) + breadth;
-
-    plane[1][2] = 0.0f;
-    plane[2][2] = 0.0f;
-    plane[3][2] = 0.0f;
-    plane[4][2] = 0.0f;
+    plane[1] = glm::vec4(left, -glm::dot(eye, left) + width);
+    plane[2] = glm::vec4(-left, glm::dot(eye, left) + width);
+    plane[3] = glm::vec4(front, -glm::dot(eye, front) + breadth);
+    plane[4] = glm::vec4(-front, glm::dot(eye, front) + breadth);
 
     // disable the near and far planes
-    plane[0][0] = plane[0][1] = 0.0f;
-    plane[0][2] = 1.0f;
-    plane[0][3] = -1.0e6;
-    plane[5][0] = plane[0][1] = 0.0f;
-    plane[5][2] = 1.0f;
-    plane[5][3] = -1.0e6;
+    plane[0] = glm::vec4(0, 0, 1, -1.0e6);
+    plane[5] = glm::vec4(0, 0, 1, -1.0e6);
 
     planeCount = 5;
 

--- a/src/game/Frustum.cxx
+++ b/src/game/Frustum.cxx
@@ -59,13 +59,13 @@ void Frustum::setView(const glm::vec3 &_eye, const glm::vec3 &_target)
     billboardMatrix[2][3] = 0;
 
     // compute vectors of frustum edges
-    const float xs = fabsf(1.0f / projectionMatrix[0][0]);
-    const float ys = fabsf(1.0f / projectionMatrix[1][1]);
+    auto xs = right / fabsf(projectionMatrix[0][0]);
+    auto ys = up / fabsf(projectionMatrix[1][1]);
     glm::vec3 edge[4];
-    edge[0] = z - xs * right - ys * up;
-    edge[1] = z + xs * right - ys * up;
-    edge[2] = z + xs * right + ys * up;
-    edge[3] = z - xs * right + ys * up;
+    edge[0] = z - xs - ys;
+    edge[1] = z + xs - ys;
+    edge[2] = z + xs + ys;
+    edge[3] = z - xs + ys;
 
     // make frustum planes
     plane[0] = glm::vec4(z, -glm::dot(eye, z) - m_near);

--- a/src/game/Intersect.cxx
+++ b/src/game/Intersect.cxx
@@ -815,7 +815,6 @@ IntersectLevel testAxisBoxInFrustum(const Extents& extents,
     static float i[3]; // inside point  (assuming partial)
     static float o[3]; // outside point (assuming partial)
     static float len;
-    static const float* p; // the plane
     IntersectLevel result = Contained;
 
     // FIXME - 0 is the near clip plane, not that useful really?
@@ -825,8 +824,7 @@ IntersectLevel testAxisBoxInFrustum(const Extents& extents,
 
     for (s = 1 /* NOTE: not 0 */; s < planeCount; s++)
     {
-
-        p = frustum->getSide(s);
+        auto p = frustum->getSide(s); // the plane
 
         // setup the inside/outside corners
         // this can be determined easily based

--- a/src/geometry/BillboardSceneNode.cxx
+++ b/src/geometry/BillboardSceneNode.cxx
@@ -356,7 +356,7 @@ void            BillboardSceneNode::BillboardRenderNode::render()
     // will move in the direction of the view, which isn't necessarily
     // the direction to the billboard from the eye.
     ViewFrustum& frustum = RENDERER.getViewFrustum();
-    const GLfloat* eye = frustum.getEye();
+    const auto eye = frustum.getEye();
     const GLfloat* sphere = sceneNode->getSphere();
     GLfloat dir[3], d;
     dir[0] = eye[0] - sphere[0];

--- a/src/geometry/MeshPolySceneNode.cxx
+++ b/src/geometry/MeshPolySceneNode.cxx
@@ -262,7 +262,7 @@ MeshPolySceneNode::~MeshPolySceneNode()
 bool MeshPolySceneNode::cull(const ViewFrustum& frustum) const
 {
     // cull if eye is behind (or on) plane
-    const GLfloat* eye = frustum.getEye();
+    const auto eye = frustum.getEye();
     if (((eye[0] * plane[0]) + (eye[1] * plane[1]) + (eye[2] * plane[2]) +
             plane[3]) <= 0.0f)
         return true;

--- a/src/geometry/MeshSceneNode.cxx
+++ b/src/geometry/MeshSceneNode.cxx
@@ -192,9 +192,9 @@ MeshSceneNode::~MeshSceneNode()
 
 inline int MeshSceneNode::calcNormalLod(const ViewFrustum& vf)
 {
-    const float* e = vf.getEye();
+    const auto e = vf.getEye();
     const float* s = getSphere();
-    const float* d = vf.getDirection();
+    const auto d = vf.getDirection();
     const float dist = (d[0] * (s[0] - e[0])) +
                        (d[1] * (s[1] - e[1])) +
                        (d[2] * (s[2] - e[2]));
@@ -211,9 +211,9 @@ inline int MeshSceneNode::calcNormalLod(const ViewFrustum& vf)
 inline int MeshSceneNode::calcShadowLod(const ViewFrustum& vf)
 {
     // FIXME: adjust for ray direction
-    const float* e = vf.getEye();
+    const auto e = vf.getEye();
     const float* s = getSphere();
-    const float* d = vf.getDirection();
+    const auto d = vf.getDirection();
     const float dist = (d[0] * (s[0] - e[0])) +
                        (d[1] * (s[1] - e[1])) +
                        (d[2] * (s[2] - e[2]));

--- a/src/geometry/OccluderSceneNode.cxx
+++ b/src/geometry/OccluderSceneNode.cxx
@@ -85,7 +85,7 @@ OccluderSceneNode::~OccluderSceneNode()
 bool OccluderSceneNode::cull(const ViewFrustum& frustum) const
 {
     // cull if eye is behind (or on) plane
-    const GLfloat* eye = frustum.getEye();
+    const auto eye = frustum.getEye();
     if (((eye[0] * plane[0]) + (eye[1] * plane[1]) + (eye[2] * plane[2]) +
             plane[3]) <= 0.0f)
         return true;

--- a/src/geometry/SceneNode.cxx
+++ b/src/geometry/SceneNode.cxx
@@ -116,6 +116,13 @@ void            SceneNode::addLight(SceneRenderer&)
     // do nothing
 }
 
+GLfloat SceneNode::getDistance(const glm::vec3 &eye) const
+{
+    return (eye[0] - sphere[0]) * (eye[0] - sphere[0]) +
+           (eye[1] - sphere[1]) * (eye[1] - sphere[1]) +
+           (eye[2] - sphere[2]) * (eye[2] - sphere[2]);
+}
+
 GLfloat         SceneNode::getDistance(const GLfloat* eye) const
 {
     return (eye[0] - sphere[0]) * (eye[0] - sphere[0]) +
@@ -130,7 +137,7 @@ bool            SceneNode::cull(const ViewFrustum& view) const
     const int planeCount = view.getPlaneCount();
     for (int i = 0; i < planeCount; i++)
     {
-        const GLfloat* norm = view.getSide(i);
+        const auto norm = view.getSide(i);
         const GLfloat d = (sphere[0] * norm[0]) +
                           (sphere[1] * norm[1]) +
                           (sphere[2] * norm[2]) + norm[3];

--- a/src/geometry/SphereSceneNode.cxx
+++ b/src/geometry/SphereSceneNode.cxx
@@ -248,7 +248,7 @@ void SphereSceneNode::addRenderNodes(SceneRenderer& renderer)
 {
     const ViewFrustum& view = renderer.getViewFrustum();
     const float* s = getSphere();
-    const float* e = view.getEye();
+    const auto e = view.getEye();
     const float dx = e[0] - s[0];
     const float dy = e[1] - s[1];
     const float dz = e[2] - s[2];

--- a/src/geometry/TankSceneNode.cxx
+++ b/src/geometry/TankSceneNode.cxx
@@ -255,7 +255,7 @@ void TankSceneNode::addRenderNodes(SceneRenderer& renderer)
     // if drawing in sorted order then decide which order
     if (transparent || narrow)
     {
-        const GLfloat* eye = view.getEye();
+        const auto eye = view.getEye();
         GLfloat dx = eye[0] - mySphere[0];
         GLfloat dy = eye[1] - mySphere[1];
         const float radians = (float)(azimuth * DEG2RAD);

--- a/src/geometry/TriWallSceneNode.cxx
+++ b/src/geometry/TriWallSceneNode.cxx
@@ -270,7 +270,7 @@ TriWallSceneNode::~TriWallSceneNode()
 bool            TriWallSceneNode::cull(const ViewFrustum& frustum) const
 {
     // cull if eye is behind (or on) plane
-    const GLfloat* eye = frustum.getEye();
+    const auto eye = frustum.getEye();
     if (((eye[0] * plane[0]) + (eye[1] * plane[1]) + (eye[2] * plane[2]) +
             plane[3]) <= 0.0f)
         return true;

--- a/src/geometry/ViewFrustum.cxx
+++ b/src/geometry/ViewFrustum.cxx
@@ -32,31 +32,31 @@ ViewFrustum::~ViewFrustum()
 void            ViewFrustum::executeProjection() const
 {
     glMatrixMode(GL_PROJECTION);
-    glLoadMatrixf(projectionMatrix);
+    glLoadMatrixf(glm::value_ptr(projectionMatrix));
     glMatrixMode(GL_MODELVIEW);
 }
 
 void            ViewFrustum::executeDeepProjection() const
 {
     glMatrixMode(GL_PROJECTION);
-    glLoadMatrixf(deepProjectionMatrix);
+    glLoadMatrixf(glm::value_ptr(deepProjectionMatrix));
     glMatrixMode(GL_MODELVIEW);
 }
 
 void            ViewFrustum::executeView() const
 {
-    glMultMatrixf(viewMatrix);
+    glMultMatrixf(glm::value_ptr(viewMatrix));
 }
 
 void            ViewFrustum::executeOrientation() const
 {
-    glMultMatrixf(viewMatrix);
+    glMultMatrixf(glm::value_ptr(viewMatrix));
     glTranslatef(eye[0], eye[1], eye[2]);
 }
 
 void            ViewFrustum::executeBillboard() const
 {
-    glMultMatrixf(billboardMatrix);
+    glMultMatrixf(glm::value_ptr(billboardMatrix));
 }
 
 // Local Variables: ***

--- a/src/geometry/WallSceneNode.cxx
+++ b/src/geometry/WallSceneNode.cxx
@@ -89,7 +89,7 @@ void            WallSceneNode::setPlane(const GLfloat _plane[4])
 bool            WallSceneNode::cull(const ViewFrustum& frustum) const
 {
     // cull if eye is behind (or on) plane
-    const GLfloat* eye = frustum.getEye();
+    const auto eye = frustum.getEye();
     const float eyedot = (eye[0] * plane[0]) +
                          (eye[1] * plane[1]) +
                          (eye[2] * plane[2]) + plane[3];
@@ -110,7 +110,7 @@ bool            WallSceneNode::cull(const ViewFrustum& frustum) const
     bool inside = true;
     for (i = 0; i < planeCount; i++)
     {
-        const GLfloat* norm = frustum.getSide(i);
+        const auto norm = frustum.getSide(i);
         d[i] = (mySphere[0] * norm[0]) +
                (mySphere[1] * norm[1]) +
                (mySphere[2] * norm[2]) + norm[3];
@@ -136,7 +136,7 @@ bool            WallSceneNode::cull(const ViewFrustum& frustum) const
     {
         if (d[i] >= 0.0f)
             continue;
-        const GLfloat* norm = frustum.getSide(i);
+        const auto norm = frustum.getSide(i);
         const GLfloat c = norm[0]*plane[0] + norm[1]*plane[1] + norm[2]*plane[2];
         if (d2[i] > mySphere[3] * (1.0f - c*c))
             return true;

--- a/src/ogl/OpenGLLight.cxx
+++ b/src/ogl/OpenGLLight.cxx
@@ -209,7 +209,7 @@ void OpenGLLight::calculateImportance(const ViewFrustum& frustum)
 
     // check if the light is in front of the front viewing plane
     bool sphereCull = true;
-    const GLfloat* p = frustum.getDirection();
+    const auto p = frustum.getViewPlane();
     const float fd = (p[0] * pos[0]) +
                      (p[1] * pos[1]) +
                      (p[2] * pos[2]) + p[3];
@@ -221,7 +221,7 @@ void OpenGLLight::calculateImportance(const ViewFrustum& frustum)
         const int planeCount = frustum.getPlaneCount();
         for (int i = 1; i < planeCount; i++)
         {
-            const float* plane = frustum.getSide(i);
+            const auto plane = frustum.getSide(i);
             const float len = (plane[0] * pos[0]) +
                               (plane[1] * pos[1]) +
                               (plane[2] * pos[2]) + plane[3];
@@ -234,7 +234,7 @@ void OpenGLLight::calculateImportance(const ViewFrustum& frustum)
     }
 
     // calculate the distance
-    const GLfloat* eye = frustum.getEye();
+    const auto eye = frustum.getEye();
     const float v[3] =
     {
         (eye[0] - pos[0]),

--- a/src/ogl/RenderNode.cxx
+++ b/src/ogl/RenderNode.cxx
@@ -136,6 +136,25 @@ static int nodeCompare(const void *a, const void* b)
         return +1;
 }
 
+void RenderNodeGStateList::sort(const glm::vec3 &e)
+{
+    // calculate distances from the eye (squared)
+    for (int i = 0; i < count; i++)
+    {
+        const GLfloat* p = list[i].node->getPosition();
+        const float dx = (p[0] - e[0]);
+        const float dy = (p[1] - e[1]);
+        const float dz = (p[2] - e[2]);
+        list[i].depth = ((dx * dx) + (dy * dy) + (dz * dz));
+    }
+
+    // sort from farthest to closest
+    qsort (list, count, sizeof(Item), nodeCompare);
+
+    return;
+}
+
+
 void RenderNodeGStateList::sort(const GLfloat* e)
 {
     // calculate distances from the eye (squared)

--- a/src/scene/Occluder.cxx
+++ b/src/scene/Occluder.cxx
@@ -353,7 +353,7 @@ static bool makePlane (const float* p1, const float* p2, const float* pc,
 bool Occluder::makePlanes(const Frustum* frustum)
 {
     // occluders can't have their back towards the camera
-    const float* eye = frustum->getEye();
+    const auto eye = frustum->getEye();
     const float* p = sceneNode->getPlane();
     float tmp = (p[0] * eye[0]) + (p[1] * eye[1]) + (p[2] * eye[2]) + p[3];
     if (tmp < +0.1f)
@@ -371,7 +371,7 @@ bool Occluder::makePlanes(const Frustum* frustum)
     for (int i = 0; i < vertexCount; i++)
     {
         int second = (i + vertexCount - 1) % vertexCount;
-        if (!makePlane (vertices[i], vertices[second], eye, planes[i + 1]))
+        if (!makePlane (vertices[i], vertices[second], glm::value_ptr(eye), planes[i + 1]))
             return false;
     }
 

--- a/src/scene/Octree.cxx
+++ b/src/scene/Octree.cxx
@@ -537,7 +537,7 @@ void OctreeNode::getFrustumList () const
     {
         if (F2BSORT)
         {
-            const float* dir = CullFrustum->getDirection();
+            const auto dir = CullFrustum->getDirection();
             unsigned char dirbits = 0;
             if (dir[0] < 0.0f) dirbits |= (1 << 0);
             if (dir[1] < 0.0f) dirbits |= (1 << 1);

--- a/src/scene/ZSceneDatabase.cxx
+++ b/src/scene/ZSceneDatabase.cxx
@@ -221,7 +221,6 @@ static void setupShadowPlanes(const Frustum* frustum, const float* sunDir,
     // FIXME: As a first cut, we'll assume that
     //        the frustum top points towards Z.
 
-    const float* eye = frustum->getEye();
     if (frustum->getUp()[2] < 0.999f)
     {
         planeCount = 0;
@@ -239,6 +238,7 @@ static void setupShadowPlanes(const Frustum* frustum, const float* sunDir,
     // 3: bottom
     // 4: top
 
+    const auto eye = frustum->getEye();
     planeCount = 2;
     float edge[2];
     // left edge
@@ -360,7 +360,7 @@ void ZSceneDatabase::addRenderNodes(SceneRenderer& renderer)
 {
     int i;
     const ViewFrustum& frustum = renderer.getViewFrustum();
-    const float* eye = frustum.getEye();
+    const auto eye = frustum.getEye();
 
     // see if we need an octree, or if it needs to be rebuilt
     setupCullList();


### PR DESCRIPTION
Rewrote Frustum.* using glm
The Model View Matrix has been rebuilt with a single glm method (glm::lookAt)
I cannot find in glm the bzflag projection matrix as it is. Maybe it is wrong in bzflag?
For now I keep that as it was before