### PR TITLE
Change `bz_getSpawnPointWithin` to return success status

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 BZFlag 2.4.19
 -------------
 
+* Add bz_isWithinWorldBoundaries to API - Vladimir Jimenez
 * Use teleporter names in /saveworld .obj exports - Vladimir Jimenez
 * Add bz_getSpawnPointWithin to API - Vladimir Jimenez
 * Fix NetHandler compiler errors on Alpine Linux - Jim Melton

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -2008,7 +2008,7 @@ private:
 };
 
 BZF_API void bz_getRandomPoint ( bz_CustomZoneObject *obj, float *randomPos );
-BZF_API void bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float *randomPos );
+BZF_API bool bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float *randomPos );
 
 class bz_CustomMapObjectHandler
 {

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -2008,7 +2008,7 @@ private:
 };
 
 BZF_API void bz_getRandomPoint ( bz_CustomZoneObject *obj, float *randomPos );
-BZF_API bool bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float *randomPos );
+BZF_API bool bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float randomPos[3] );
 
 class bz_CustomMapObjectHandler
 {

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -2009,6 +2009,7 @@ private:
 
 BZF_API void bz_getRandomPoint ( bz_CustomZoneObject *obj, float *randomPos );
 BZF_API bool bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float randomPos[3] );
+BZF_API bool bz_isWithinWorldBoundaries ( float pos[3] );
 
 class bz_CustomMapObjectHandler
 {

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -3339,7 +3339,7 @@ BZF_API void bz_getRandomPoint ( bz_CustomZoneObject *obj, float *randomPos )
     }
 }
 
-BZF_API bool bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float *randomPos )
+BZF_API bool bz_getSpawnPointWithin ( bz_CustomZoneObject *obj, float randomPos[3] )
 {
     TimeKeeper start = TimeKeeper::getCurrent();
     float maxZ = bz_getWorldMaxHeight();

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -3374,15 +3374,14 @@ BZF_API bool bz_isWithinWorldBoundaries ( float pos[3] )
         return false;
     }
 
-    float positionFudge = 10.0f; // linear distance
     float worldSize = bz_getBZDBInt("_worldSize");
 
-    if (abs(pos[1]) >= (worldSize * 0.5f) + positionFudge)
+    if (abs(pos[1]) >= (worldSize * 0.5f))
     {
         return false;
     }
 
-    if (abs(pos[0]) >= (worldSize * 0.5f) + positionFudge)
+    if (abs(pos[0]) >= (worldSize * 0.5f))
     {
         return false;
     }


### PR DESCRIPTION
Introduced in #229, `bz_getSpawnPointWithin` currently has no way of indicating to the plugin that it was unsuccessful in finding a safe spawn position for a player within the given parameters.

This PR changes the return type of `bz_getSpawnPointWithin` from `void` to `bool` where the boolean is whether or not it was successful in finding a spawn position. Since 2.4.20 hasn't been released, I'd argue it's safe to make an API change to something that's still considered under development.

Another change in this PR is checking whether or not the position is within the world boundaries. By definition, a "spawn position" should not be outside the world boundaries and that's what this function is supposed to do.