### PR TITLE
Optional replacement of short radar forward tick with dashed forward line

### DIFF
--- a/include/BZDBCache.h
+++ b/include/BZDBCache.h
@@ -65,6 +65,7 @@ public:
     static Int   radarStyle;
     static Float radarTankPixels;
     static Int   leadingShotLine;
+    static Int   radarForwardMarker;
     static Float linedRadarShots;
     static Float sizedRadarShots;
     static Int   radarPosition;

--- a/src/bzflag/GUIOptionsMenu.cxx
+++ b/src/bzflag/GUIOptionsMenu.cxx
@@ -132,6 +132,17 @@ GUIOptionsMenu::GUIOptionsMenu()
     option->update();
     listHUD.push_back(option);
 
+    // radar marker for forward direction
+    option = new HUDuiList;
+    option->setFontFace(fontFace);
+    option->setLabel("Radar Forward Marker:");
+    option->setCallback(callback, "m");
+    options = &option->getList();
+    options->push_back(std::string("Tick"));
+    options->push_back(std::string("Line"));
+    option->update();
+    listHUD.push_back(option);
+
     // set radar position
     option = new HUDuiList;
     option->setFontFace(fontFace);
@@ -403,6 +414,8 @@ void            GUIOptionsMenu::resize(int _width, int _height)
         ((HUDuiList*)listHUD[i++])->setIndex(static_cast<int>(BZDB.eval("linedradarshots")));
         // Radar Shot Line
         ((HUDuiList*)listHUD[i++])->setIndex(static_cast<int>(BZDB.eval("leadingShotLine")));
+        // Radar Forward Marker
+        ((HUDuiList*)listHUD[i++])->setIndex(static_cast<int>(BZDB.eval("radarForwardMarker")));
         // Radar Position
         ((HUDuiList*)listHUD[i++])->setIndex(static_cast<int>(BZDB.eval("radarPosition")));
         // Colored shots on radar
@@ -524,6 +537,10 @@ void            GUIOptionsMenu::callback(HUDuiControl* w, const void* data)
 
     case 'F':
         BZDB.setInt("leadingShotLine", list->getIndex());
+        break;
+
+    case 'm':
+        BZDB.setInt("radarForwardMarker", list->getIndex());
         break;
 
     case 'P':

--- a/src/bzflag/RadarRenderer.cxx
+++ b/src/bzflag/RadarRenderer.cxx
@@ -743,11 +743,29 @@ void RadarRenderer::render(SceneRenderer& renderer, bool blank, bool observer)
         // always up
         glPopMatrix();
 
-        // forward tick
-        glBegin(GL_LINES);
-        glVertex2f(0.0f, radarRange - ps);
-        glVertex2f(0.0f, radarRange - 4.0f * ps);
+        // forward tick/line
+        bool isLineRadarMarker = (BZDB.eval("radarForwardMarker") == 1); 
+        if (isLineRadarMarker)
+        {
+            glPushAttrib(GL_LINE_STIPPLE);
+            glLineStipple(1, 0xF0F0);
+            glEnable(GL_LINE_STIPPLE);
+            glColor3f(0.7f, 0.425f, 0.1f);
+
+            glBegin(GL_LINES);
+            glVertex2f(0.0f, radarRange - ps);
+            glVertex2f(0.0f, 0.0f);
+        }
+        else
+        {
+            glBegin(GL_LINES);
+            glVertex2f(0.0f, radarRange - ps);
+            glVertex2f(0.0f, radarRange - 4.0f * ps);
+        }
         glEnd();
+        if (isLineRadarMarker) glPopAttrib();
+
+
 
         if (!observer)
         {

--- a/src/bzflag/defaultBZDB.cxx
+++ b/src/bzflag/defaultBZDB.cxx
@@ -92,6 +92,7 @@ DefaultDBItem defaultDBItems[] =
     { "scrollPages",      "20",           true,   StateDatabase::ReadWrite,   NULL },
     { "remoteSounds",     "1",            true,   StateDatabase::ReadWrite,   NULL },
     { "leadingShotLine",      "1",            true,   StateDatabase::ReadWrite,   NULL },
+    { "radarForwardMarker",   "1",            true,   StateDatabase::ReadWrite,   NULL },
     { "saveIdentity",     "2",            true,   StateDatabase::ReadWrite,   NULL },
     { "showCollisionGrid",    "0",            true,   StateDatabase::ReadWrite,   NULL },
     { "showCullingGrid",      "0",            true,   StateDatabase::ReadWrite,   NULL },

--- a/src/common/BZDBCache.cxx
+++ b/src/common/BZDBCache.cxx
@@ -29,6 +29,7 @@ BZDBCache::Bool  BZDBCache::smooth;
 BZDBCache::Bool  BZDBCache::colorful;
 BZDBCache::Bool  BZDBCache::animatedTreads;
 BZDBCache::Int   BZDBCache::leadingShotLine;
+BZDBCache::Int   BZDBCache::radarForwardMarker;
 BZDBCache::Int   BZDBCache::radarStyle;
 BZDBCache::Float BZDBCache::radarTankPixels;
 BZDBCache::Float BZDBCache::linedRadarShots;
@@ -113,6 +114,7 @@ void BZDBCache::init()
     BZDB.addCallback("animatedTreads", clientCallback, NULL);
     BZDB.addCallback("shotLength", clientCallback, NULL);
     BZDB.addCallback("leadingShotLine", clientCallback, NULL);
+    BZDB.addCallback("radarForwardMarker", clientCallback, NULL);
     BZDB.addCallback("radarPosition", clientCallback, NULL);
     BZDB.addCallback("flagChunks", clientCallback, NULL);
     BZDB.addCallback("pulseRate", clientCallback, NULL);
@@ -203,6 +205,8 @@ void BZDBCache::clientCallback(const std::string& name, void *)
         shotLength = BZDB.eval("shotLength");
     else if (name == "leadingShotLine")
         leadingShotLine = BZDB.evalInt("leadingShotLine");
+    else if (name == "radarForwardMarker")
+        leadingShotLine = BZDB.evalInt("radarForwardMarker");
     else if (name == "radarPosition")
         radarPosition = BZDB.evalInt("radarPosition");
     else if (name == "flagChunks")


### PR DESCRIPTION
- Draw a dashed line in radar in tank heading direction instead of small tick at radar border
- Add GUI menu entry "Radar Forward Marker:" Tick/Line

... a big aiming aid for me ;-) 