### PR TITLE
Fix autogen having CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+autogen.sh text eol=lf


### PR DESCRIPTION
This fixes `autogen.sh` having CRLF line endings (on Windows).