### PR TITLE
Fix multiple issues with SDL 2 window creation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 
 BZFlag 2.4.21
 -------------
+* Fix many issues with SDL 2 window management - Joshua Bodine, Scott Wichser
 
 
 BZFlag 2.4.20  "Do You See What I See?" (2020-04-24)

--- a/src/bzflag/MainWindow.cxx
+++ b/src/bzflag/MainWindow.cxx
@@ -148,6 +148,7 @@ void            MainWindow::setFullscreen()
 {
     isFullscreen = false;
     toggleFullscreen();
+    window->create();
 }
 
 void            MainWindow::toggleFullscreen()

--- a/src/bzflag/MainWindow.cxx
+++ b/src/bzflag/MainWindow.cxx
@@ -36,6 +36,9 @@ MainWindow::MainWindow(BzfWindow* _window, BzfJoystick* _joystick) :
     minHeight(MinY),
     faulting(false)
 {
+    if (!window->create())
+        faulting = true;
+
     window->addResizeCallback(resizeCB, this);
     resize();
 }
@@ -151,13 +154,14 @@ void            MainWindow::setFullscreen()
 {
     isFullscreen = false;
     toggleFullscreen();
-    window->create();
 }
 
 void            MainWindow::toggleFullscreen()
 {
     isFullscreen = !isFullscreen;
     window->setFullscreen(isFullscreen);
+    window->create();
+    resize();
 }
 
 void            MainWindow::setFullView(bool _isFullView)
@@ -283,8 +287,6 @@ void            MainWindow::resize()
 {
     window->getSize(trueWidth, trueHeight);
     window->makeCurrent();
-    if (!window->create())
-        faulting = true;
     setQuadrant(quadrant);
 }
 

--- a/src/bzflag/MainWindow.cxx
+++ b/src/bzflag/MainWindow.cxx
@@ -37,6 +37,7 @@ MainWindow::MainWindow(BzfWindow* _window, BzfJoystick* _joystick) :
     faulting(false)
 {
     window->addResizeCallback(resizeCB, this);
+    resize();
 }
 
 MainWindow::~MainWindow()
@@ -49,6 +50,7 @@ void            MainWindow::setMinSize(int _minWidth, int _minHeight)
     minWidth = _minWidth;
     minHeight = _minHeight;
     window->setMinSize(minWidth, minHeight);
+    resize();
 }
 
 void            MainWindow::setPosition(int x, int y)
@@ -59,6 +61,7 @@ void            MainWindow::setPosition(int x, int y)
 void            MainWindow::setSize(int _width, int _height)
 {
     window->setSize(_width, _height);
+    resize();
 }
 
 void            MainWindow::showWindow(bool on)

--- a/src/bzflag/bzflag.cxx
+++ b/src/bzflag/bzflag.cxx
@@ -1169,9 +1169,6 @@ int         main(int argc, char** argv)
     // enable vsync if needed
     pmainWindow->getWindow()->setVerticalSync(BZDB.evalInt("saveEnergy") == 2);
 
-    // Make sure the window is created
-    pmainWindow->getWindow()->callResizeCallbacks();
-
     // get sound files.  must do this after creating the window because
     // DirectSound is a bonehead API.
     if (!noAudio)

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -7568,6 +7568,9 @@ void            startPlaying(BzfDisplay* _display,
             }
         }
     }
+    // otherwise, use the default resolution if we do switch to fullscreen
+    else
+        display->setDefaultResolution();
 
     // grab mouse if we should
     if (shouldGrabMouse())

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -1153,7 +1153,7 @@ static void     doEvent(BzfDisplay *disply)
         }
 
         // ungrab the mouse if we're running full screen
-        if (mainWindow->getFullscreen())
+        if (mainWindow->getFullscreen() && !unmapped) // skip if already unmapped to avoid losing previous resolution
         {
             preUnmapFormat = -1;
             if (disply->getNumResolutions() > 1)

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -7530,11 +7530,7 @@ void            startPlaying(BzfDisplay* _display,
     {
         videoFormat = BZDB.get("resolution");
         if (videoFormat.length() != 0)
-        {
             format = display->findResolution(videoFormat.c_str());
-            if (format >= 0)
-                mainWindow->getWindow()->callResizeCallbacks();
-        }
     };
     // set the resolution (only if in full screen mode)
     if (!BZDB.isSet("_window") && BZDB.isSet("resolution"))

--- a/src/platform/SDL2Window.cxx
+++ b/src/platform/SDL2Window.cxx
@@ -32,6 +32,9 @@ SDLWindow::~SDLWindow()
 {
     // Restore the original gamma when we exit the client
     setGamma(origGamma);
+
+    if (windowId != NULL)
+        SDL_DestroyWindow(windowId);
 }
 
 void SDLWindow::setTitle(const char *_title)

--- a/src/platform/SDL2Window.cxx
+++ b/src/platform/SDL2Window.cxx
@@ -279,6 +279,24 @@ bool SDLWindow::create(void)
             return false;
         }
     }
+
+    // Depending on the distribution (or possibly the window manager), SDL will not recognize the new window resolution
+    // and will keep returning the previous resolution when SDL_GetWindowSize() is called, until a period of time has
+    // passed and events have been pumped. Wait up to two seconds for the correct resolution to start being returned,
+    // checking every quarter second, to avoid repeating the window destruction/re-creation process based on bad data.
+    int currentWidth, currentHeight, resCheckLoops = 0;
+
+    do
+    {
+        SDL_PumpEvents();
+        SDL_GetWindowSize(windowId, &currentWidth, &currentHeight);
+
+        if(currentWidth == targetWidth && currentHeight == targetHeight)
+            break;
+
+        TimeKeeper::sleep(0.25f);
+    }
+    while (resCheckLoops++ < 8);
 #endif // __linux__
 
     // Apply filters due to resize event issues on Linux (see the explanation above for SDLWindowEventFilter())

--- a/src/platform/SDL2Window.cxx
+++ b/src/platform/SDL2Window.cxx
@@ -167,6 +167,17 @@ void SDLWindow::swapBuffers()
 
 bool SDLWindow::create(void)
 {
+#ifdef __APPLE__
+    // On macOS, if the window is in maximized windowed state and we switch to native fullscreen mode, when we come
+    // back to windowed mode, SDL tries to create a window with the full maximized resolution. This doesn't fit on
+    // the screen because we're no longer maximized. In this scenario, store the original windowed resolution, and
+    // revert to that setting after toggling from a maximized window to fullscreen and back out.
+    static const int origWindowSizeX = base_width, origWindowSizeY = base_height;
+
+    if(windowId && glContext && fullScreen && SDL_GetWindowFlags(windowId) & SDL_WINDOW_MAXIMIZED)
+        setSize(origWindowSizeX, origWindowSizeY);
+#endif
+
     int targetWidth, targetHeight;
     getSize(targetWidth, targetHeight);
     SDL_bool windowWasGrabbed = SDL_FALSE;

--- a/src/platform/SDL2Window.cxx
+++ b/src/platform/SDL2Window.cxx
@@ -148,7 +148,10 @@ void SDLWindow::swapBuffers()
     if (! SDL_GL_GetSwapInterval())
         return;
 
-    const int maxRunawayFPS = 65;
+    int maxRunawayFPS = 65;
+    SDL_DisplayMode desktopDisplayMode;
+    if (SDL_GetDesktopDisplayMode(0, &desktopDisplayMode) == 0)
+        maxRunawayFPS = desktopDisplayMode.refresh_rate + 5;
 
     static TimeKeeper lastFrame = TimeKeeper::getSunGenesisTime();
     const TimeKeeper now = TimeKeeper::getCurrent();

--- a/src/platform/SDL2Window.cxx
+++ b/src/platform/SDL2Window.cxx
@@ -101,10 +101,21 @@ void SDLWindow::getMouse(int& _x, int& _y) const
 
 void SDLWindow::setSize(int _width, int _height)
 {
+    // workaround for two issues on Linux, where resizing by dragging the window corner causes glitching, and where
+    // iconifying or switching applications while using a scaled fullscreen resolution causes the non-fullscreen
+    // window resolution to assume the fullscreen resolution
+#ifdef __linux__
+    if(!fullScreen)
+    {
+        base_width  = _width;
+        base_height = _height;
+    }
+#else
     base_width  = _width;
     base_height = _height;
     if (!fullScreen && windowId)
         SDL_SetWindowSize(windowId, base_width, base_height);
+#endif // __linux__
 }
 
 void SDLWindow::getSize(int& width, int& height) const


### PR DESCRIPTION
Issue #246 lists several bugs with our SDL 2 window creation process. While digging into several of those, I also discovered several other regressions (changes that broke other features, code that was transplanted but not entirely, etc.) introduced into our window creation process over several commits. This fixes several issues with our window creation process, including #201 (this is basically a rework of #238) for the multiple monitor Linux issue, #241 for the fullscreen toggle issue on macOS, and some other issues I discovered along the way. ~~I still haven't figured out #245 yet.~~