### PR TITLE
Buffer udp

### DIFF
--- a/include/NetHandler.h
+++ b/include/NetHandler.h
@@ -111,11 +111,13 @@ public:
 
         buffer is the received message
 
+        buffLen is the size of the buffer
+
         uaddr is the identifier of the remote address
 
         udpLinkRequest report if the received message is a valid udpLinkRequest
     */
-    static int    udpReceive(char *buffer, struct sockaddr_in *uaddr,
+    static int    udpReceive(char *buffer, int &buffLen, struct sockaddr_in *uaddr,
                              bool &udpLinkRequest);
 
     /**

--- a/src/bzfs/bzfs.cxx
+++ b/src/bzfs/bzfs.cxx
@@ -7665,7 +7665,7 @@ int main(int argc, char **argv)
                     unsigned char ubuf[MaxPacketLen];
                     bool     udpLinkRequest;
                     // interface to the UDP Receive routines
-                    int buffLen;
+                    int buffLen = MaxPacketLen;
                     int id = NetHandler::udpReceive((char *) ubuf, buffLen, &uaddr,
                                                     udpLinkRequest);
                     if (id == -1)
@@ -7688,12 +7688,12 @@ int main(int argc, char **argv)
                             sendUDPupdate(id);
 
                         unsigned char *buf = ubuf;
-                        uint16_t len;
 
                         // handle the command for UDP
                         // checking if more messages are on the same datagram
                         while (buffLen >= 4)
                         {
+                            uint16_t len;
                             handleCommand(id, buf, true);
                             nboUnpackUShort(buf, len);
                             buf     += len + 4;

--- a/src/game/NetHandler.cxx
+++ b/src/game/NetHandler.cxx
@@ -136,11 +136,10 @@ int NetHandler::getUdpSocket()
     return udpSocket;
 }
 
-int NetHandler::udpReceive(char *buffer, struct sockaddr_in *uaddr,
+int NetHandler::udpReceive(char *buffer, int &n, struct sockaddr_in *uaddr,
                            bool &udpLinkRequest)
 {
     AddrLen recvlen = sizeof(*uaddr);
-    int n;
     uint16_t len;
     uint16_t code;
     while (true)

--- a/src/game/NetHandler.cxx
+++ b/src/game/NetHandler.cxx
@@ -136,7 +136,7 @@ int NetHandler::getUdpSocket()
     return udpSocket;
 }
 
-int NetHandler::udpReceive(char *buffer, int &n, struct sockaddr_in *uaddr,
+int NetHandler::udpReceive(char *buffer, int &buffLen, struct sockaddr_in *uaddr,
                            bool &udpLinkRequest)
 {
     AddrLen recvlen = sizeof(*uaddr);
@@ -144,13 +144,13 @@ int NetHandler::udpReceive(char *buffer, int &n, struct sockaddr_in *uaddr,
     uint16_t code;
     while (true)
     {
-        n = recvfrom(udpSocket, buffer, MaxUDPPacketLen, 0, (struct sockaddr *) uaddr,
+        buffLen = recvfrom(udpSocket, buffer, buffLen, 0, (struct sockaddr *) uaddr,
                      &recvlen);
-        if ((n < 0) || (n >= 4))
+        if ((buffLen < 0) || (buffLen >= 4))
             break;
     }
     // Error receiving data (or no data)
-    if (n < 0 || uaddr->sin_port < 1024)
+    if (buffLen < 0 || uaddr->sin_port < 1024)
         return -1;
 
     // read head
@@ -158,7 +158,7 @@ int NetHandler::udpReceive(char *buffer, int &n, struct sockaddr_in *uaddr,
     buf = nboUnpackUShort(buf, len);
     buf = nboUnpackUShort(buf, code);
 
-    if (len + 4 > n)
+    if (len + 4 > buffLen)
         return -1;
 
 //  if (code != MsgPlayerUpdateSmall && code != MsgPlayerUpdate)
@@ -231,7 +231,7 @@ than %s:%d\n",
         logDebugMessage(4,"Player slot %d uread() %s:%d len %d from %s:%d on %i\n",
                         id,
                         inet_ntoa(netPlayer[id]->uaddr.sin_addr),
-                        ntohs(netPlayer[id]->uaddr.sin_port), n,
+                        ntohs(netPlayer[id]->uaddr.sin_port), buffLen,
                         inet_ntoa(uaddr->sin_addr), ntohs(uaddr->sin_port),
                         udpSocket);
 #ifdef NETWORK_STATS


### PR DESCRIPTION
The current status:
Any time there is a "begin shot" there is also an update of the tank position.
The idea about sending these two messages was to see bullets starting where a tank is.
Unfortunately these packets are sent always using 2 different datagrams, at least on UDP, bzfs does not support UDP buffering.
When tank sends a stream of shots it also send a stream of player updates.

This pull request:
Make bzfs accept buffered udp datagram (1st commit)

Make client merge player update and begin shot on the same datagram (2nd commit)

Client build with the second commit cannot shoot anymore (in UDP) with old server.

New server accept new and old clients

My proposal is to add the first commit, the bzfs handling of udp buffered messages, to 2.4, and the client changes to leave for the next protocol break. In the mean time there is a possibility to test if this reduce the massive FramePerSecond drop that sometime happens.
