### PR TITLE
More fixes for SDL2 window management

### DIFF
--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -1035,7 +1035,7 @@ static void mouseClamp()
 {
     // only clamp when it might be useful
     if (HUDDialogStack::get()->isActive() || (myTank == NULL) || !myTank->isAlive() ||
-            myTank->isPaused() || (myTank->getTeam() == ObserverTeam))
+            myTank->isPaused() || (myTank->getTeam() == ObserverTeam) || unmapped)
     {
         mainWindow->disableConfineToMotionbox();
         return;
@@ -1133,6 +1133,9 @@ static void     doEvent(BzfDisplay *disply)
         unmapped = false;
         if (shouldGrabMouse())
             mainWindow->grabMouse();
+        if(mainWindow->isGrabEnabled())
+            mainWindow->getWindow()->enableGrabMouse(true); // distinct from grabMouse(), for some reason
+        mouseClamp();
         break;
 
     case BzfEvent::Unmap:
@@ -1175,6 +1178,7 @@ static void     doEvent(BzfDisplay *disply)
 
         unmapped = true;
         mainWindow->ungrabMouse();
+        mainWindow->getWindow()->enableGrabMouse(false); // distinct from ungrabMouse(), for some reason
         break;
 
     case BzfEvent::KeyUp:

--- a/src/platform/SDL2Display.cxx
+++ b/src/platform/SDL2Display.cxx
@@ -562,6 +562,22 @@ bool SDLDisplay::setupEvent(BzfEvent& _event, const SDL_Event& event) const
     case SDL_WINDOWEVENT:
         switch (event.window.event)
         {
+#ifdef __APPLE__
+        case SDL_WINDOWEVENT_MOVED:
+        {
+            // Work around a bug in SDL2 that was causing an offset viewport on macOS when restoring a fullscreen window
+            // running at a resolution different from the desktop resolution. The issue only occurred when clicking on
+            // the application icon, not the minimized window. The window moves to a negative position, so we'll
+            // detect that and toggle windowed/full screen to fix it.
+            SDL_Window *window = SDL_GetWindowFromID(event.window.windowID);
+            if ((event.window.data1 < 0 || event.window.data2 < 0) && SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN)
+            {
+                SDL_SetWindowFullscreen(window, 0);
+                SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN);
+            }
+        }
+        break;
+#endif
         case SDL_WINDOWEVENT_RESIZED:
             _event.type = BzfEvent::Resize;
             _event.resize.width  = event.window.data1;


### PR DESCRIPTION
Several additional issues were discovered when validating the fixes for SDL2 window management in #251.  This can serve as a repository for fixes for these additional issues as they are completed.

- [x] #266 macOS build confines mouse after being minimized
- [ ] ~~#267 Saved resolution reset when quitting the game from taskbar/dock~~
- [x] #268 Restoring minimized window on macOS 10.15 can result in an offset viewport