### PR TITLE
Fix OBS Studio game capture on Windows.

### DIFF
--- a/src/bzflag/ControlPanel.cxx
+++ b/src/bzflag/ControlPanel.cxx
@@ -348,6 +348,8 @@ void            ControlPanel::render(SceneRenderer& _renderer)
     int   ay = (_renderer.getPanelOpacity() == 1.0f || !showTabs) ? 0
                : int(lineHeight + 4);
 
+    glPushAttrib(GL_SCISSOR_BIT);
+
     glScissor(x + messageAreaPixels[0] - 1,
               y + messageAreaPixels[1],
               messageAreaPixels[2] + 1,
@@ -572,6 +574,9 @@ void            ControlPanel::render(SceneRenderer& _renderer)
               y + messageAreaPixels[1] - 2,
               messageAreaPixels[2] + 3,
               messageAreaPixels[3] + 33);
+
+    glPopAttrib();
+
     OpenGLGState::resetState();
 
     // draw the lines around the console panel

--- a/src/bzflag/HUDRenderer.cxx
+++ b/src/bzflag/HUDRenderer.cxx
@@ -1490,6 +1490,8 @@ void            HUDRenderer::renderBox(SceneRenderer&)
     }
     glEnd();
 
+    glPushAttrib(GL_SCISSOR_BIT);
+
     // draw heading strip
     if (true /* always draw heading strip */)
     {
@@ -1696,6 +1698,8 @@ void            HUDRenderer::renderBox(SceneRenderer&)
             }
         }
     }
+
+    glPopAttrib();
 }
 
 void HUDRenderer::drawMarkersInView( int centerx, int centery, const LocalPlayer* myTank )
@@ -1748,7 +1752,6 @@ void            HUDRenderer::setOneToOnePrj()
     const int oy = window.getOriginY();
 
     // use one-to-one pixel projection
-    glScissor(ox, oy + height - viewHeight, width, viewHeight);
     glMatrixMode(GL_PROJECTION);
     window.setProjectionHUD();
     glMatrixMode(GL_MODELVIEW);

--- a/src/bzflag/HUDRenderer.cxx
+++ b/src/bzflag/HUDRenderer.cxx
@@ -1744,13 +1744,6 @@ void HUDRenderer::drawMarkersInView( int centerx, int centery, const LocalPlayer
 
 void            HUDRenderer::setOneToOnePrj()
 {
-    // get view metrics
-    const int width = window.getWidth();
-    const int height = window.getHeight();
-    const int viewHeight = window.getViewHeight();
-    const int ox = window.getOriginX();
-    const int oy = window.getOriginY();
-
     // use one-to-one pixel projection
     glMatrixMode(GL_PROJECTION);
     window.setProjectionHUD();

--- a/src/bzflag/RadarRenderer.cxx
+++ b/src/bzflag/RadarRenderer.cxx
@@ -321,6 +321,8 @@ void RadarRenderer::renderFrame(SceneRenderer& renderer)
     const int ox = window.getOriginX();
     const int oy = window.getOriginY();
 
+    glPushAttrib(GL_SCISSOR_BIT);
+
     glScissor(ox + x - 1, oy + y - 1, w + 2, h + 2);
 
     const float left = float(ox + x) - 0.5f;
@@ -398,11 +400,11 @@ void RadarRenderer::render(SceneRenderer& renderer, bool blank, bool observer)
     // render the frame
     renderFrame(renderer);
 
-    if (blank)
+    if (blank || !world)
+    {
+        glPopAttrib();
         return;
-
-    if (!world)
-        return;
+    }
 
     smooth = BZDBCache::smooth;
     const bool fastRadar = ((BZDBCache::radarStyle == 1) ||
@@ -785,6 +787,8 @@ void RadarRenderer::render(SceneRenderer& renderer, bool blank, bool observer)
         glDisable(GL_LINE_SMOOTH);
         glDisable(GL_POINT_SMOOTH);
     }
+
+    glPopAttrib();
 
     triangleCount = RenderNode::getTriangleCount();
 }

--- a/src/bzflag/SceneRenderer.cxx
+++ b/src/bzflag/SceneRenderer.cxx
@@ -845,6 +845,8 @@ void SceneRenderer::render(bool _lastFrame, bool _sameFrame,
         clearZbuffer = false;
     }
 
+    glPushAttrib(GL_SCISSOR_BIT);
+
     // the real scene
     renderScene(_lastFrame, _sameFrame, fullWindow);
 
@@ -853,6 +855,8 @@ void SceneRenderer::render(bool _lastFrame, bool _sameFrame,
         glDisable(GL_FOG);
 
     renderDimming();
+
+    glPopAttrib();
 
     triangleCount = RenderNode::getTriangleCount();
     if (background)
@@ -891,7 +895,6 @@ void SceneRenderer::renderScene(bool UNUSED(_lastFrame), bool UNUSED(_sameFrame)
     }
 
     // set scissor
-    glPushAttrib(GL_SCISSOR_BIT);
     glScissor(window->getOriginX(), window->getOriginY() + window->getHeight() - window->getViewHeight(),
               window->getWidth(), window->getViewHeight());
 
@@ -1047,7 +1050,6 @@ void SceneRenderer::renderScene(bool UNUSED(_lastFrame), bool UNUSED(_sameFrame)
     }
 
     // back to original state
-    glPopAttrib();
     if (!useHiddenLineOn && useWireframeOn)
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     glPopMatrix();

--- a/src/bzflag/SceneRenderer.cxx
+++ b/src/bzflag/SceneRenderer.cxx
@@ -472,9 +472,11 @@ void SceneRenderer::clearRadar(float opacity)
 {
     int size = window->getHeight() - window->getViewHeight();
     float op = (opacity > 1.0f) ? 1.0f : (opacity < 0.0f) ? 0.0f : opacity;
+    glPushAttrib(GL_SCISSOR_BIT);
     glScissor(window->getOriginX(), 0, size, size);
     glClearColor(0.0f, 0.0f, 0.0f, op);
     glClear(GL_COLOR_BUFFER_BIT);
+    glPopAttrib();
 }
 
 
@@ -889,6 +891,7 @@ void SceneRenderer::renderScene(bool UNUSED(_lastFrame), bool UNUSED(_sameFrame)
     }
 
     // set scissor
+    glPushAttrib(GL_SCISSOR_BIT);
     glScissor(window->getOriginX(), window->getOriginY() + window->getHeight() - window->getViewHeight(),
               window->getWidth(), window->getViewHeight());
 
@@ -1044,6 +1047,7 @@ void SceneRenderer::renderScene(bool UNUSED(_lastFrame), bool UNUSED(_sameFrame)
     }
 
     // back to original state
+    glPopAttrib();
     if (!useHiddenLineOn && useWireframeOn)
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     glPopMatrix();

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -6414,10 +6414,7 @@ void drawFrame(const float dt)
         if (BZDB.isTrue("fakecursor"))
         {
             int mx, my;
-            const int width = mainWindow->getWidth();
             const int height = mainWindow->getHeight();
-            const int ox = mainWindow->getOriginX();
-            const int oy = mainWindow->getOriginY();
             mainWindow->getWindow()->getMouse(mx, my);
             my = height - my - 1;
 

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -6376,13 +6376,19 @@ void drawFrame(const float dt)
             // normal rendering
             sceneRenderer->render();
 
-            // blit the multisample framebuffer (if enabled) to the main framebuffer
+            // blit the multisample framebuffer (if enabled) to the main framebuffer (constrained to drawing area)
             if(useMultisampling)
             {
                 glBindFramebuffer(GL_READ_FRAMEBUFFER, glFramebuffer.getFramebuffer());
                 glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-                glBlitFramebuffer(0, 0, mainWindow->getWidth(), mainWindow->getHeight(),
-                                  0, 0, mainWindow->getWidth(), mainWindow->getHeight(),
+                glBlitFramebuffer(mainWindow->getOriginX(),
+                                  mainWindow->getOriginY() + mainWindow->getHeight() - mainWindow->getViewHeight(),
+                                  mainWindow->getOriginX() + mainWindow->getWidth(),
+                                  mainWindow->getOriginY() + mainWindow->getHeight(),
+                                  mainWindow->getOriginX(),
+                                  mainWindow->getOriginY() + mainWindow->getHeight() - mainWindow->getViewHeight(),
+                                  mainWindow->getOriginX() + mainWindow->getWidth(),
+                                  mainWindow->getOriginY() + mainWindow->getHeight(),
                                   GL_COLOR_BUFFER_BIT, GL_NEAREST);
                 glBindFramebuffer(GL_FRAMEBUFFER, 0);
             }

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -5533,11 +5533,6 @@ static void     renderDialog()
 {
     if (HUDDialogStack::get()->isActive())
     {
-        const int width = mainWindow->getWidth();
-        const int height = mainWindow->getHeight();
-        const int ox = mainWindow->getOriginX();
-        const int oy = mainWindow->getOriginY();
-        glScissor(ox, oy, width, height);
         glMatrixMode(GL_PROJECTION);
         mainWindow->setProjectionPlay();
         glMatrixMode(GL_MODELVIEW);
@@ -5581,7 +5576,6 @@ static void renderRoamMouse()
 
     glPushAttrib(GL_ALL_ATTRIB_BITS);
 
-    glScissor(ox, oy, sx, sy);
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
     mainWindow->setProjectionPlay();
@@ -6421,7 +6415,6 @@ void drawFrame(const float dt)
             mainWindow->getWindow()->getMouse(mx, my);
             my = height - my - 1;
 
-            glScissor(ox, oy, width, height);
             glMatrixMode(GL_PROJECTION);
             mainWindow->setProjectionPlay();
             glMatrixMode(GL_MODELVIEW);


### PR DESCRIPTION
On Windows, trying to use game capture in OBS Studio would result in only the radar, chat panel, or altitude ticker areas redrawing.  This was due to our (incorrect?) use of glScissor.  This PR wraps our use of glScissor between glPushAttrib and glPopAttrib.  I also removed a few instances where we were setting the glScissor to the whole viewport, since that should no longer be necessary as we are restoring the scissor to the previous state after we are done.

I did notice that when the radar/panel opacity is set to full, the radar/panel area doesn't redraw in the OBS game capture.  I have not looked into that part yet.