### PR TITLE
GitHub action to ensure BZFlag builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    
+    - name: Update repositories
+      run: sudo apt-get update
 
     - name: Install dependencies
       run: sudo apt-get install g++ libtool automake autoconf libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libsdl-sound1.2-dev libcurl3-dev libc-ares-dev zlib1g-dev libncurses-dev libglew-dev make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: sudo apt-get install g++ libtool automake autoconf libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libsdl-sound1.2-dev libcurl3-dev libc-ares-dev zlib1g-dev libncurses-dev libglew-dev make
+
+    - name: Autogen
+      run: ./autogen.sh
+
+    - name: Configure
+      run: ./configure
+
+    - name: Compile
+      run: make


### PR DESCRIPTION
This creates a GitHub Action that verifies BZFlag still compiles on push and in PRs.