### PR TITLE
Use the audio buffer size the author really wants.

### DIFF
--- a/src/platform/SDLMedia.cxx
+++ b/src/platform/SDLMedia.cxx
@@ -129,8 +129,7 @@ bool            SDLMedia::openAudio()
 
     // how big a fragment to use?  we want to hold at around 1/10th of
     // a second.
-    // probably SDL is using multiple buffering, make it a 3rd
-    int fragmentSize = (int)(0.03f * (float)audioOutputRate);
+    int fragmentSize = (int)(0.1f * (float)audioOutputRate);
     int n;
 
     n = 0;


### PR DESCRIPTION
Makes sound much smoother.

We have had this in in our OpenBSD port for almost 13 years. 