### PR TITLE
Do not use isEventPending to exit from event loop

### DIFF
--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -1074,10 +1074,10 @@ static void mouseClamp()
 }
 
 
-static void     doEvent(BzfDisplay *disply)
+static bool doEvent(BzfDisplay *disply)
 {
     BzfEvent event;
-    if (!disply->getEvent(event)) return;
+    if (!disply->getEvent(event)) return false;
 
     switch (event.type)
     {
@@ -1197,6 +1197,7 @@ static void     doEvent(BzfDisplay *disply)
         /* unset */
         break;
     }
+    return true;
 }
 
 void        addMessage(const Player *_player, const std::string& msg,
@@ -3594,12 +3595,13 @@ void           processInputEvents(float maxProcessingTime)
     if (mainWindow && display)
     {
         TimeKeeper start = TimeKeeper::getCurrent();
-        while (display->isEventPending() &&
-                !CommandsStandard::isQuit() &&
+        while (!CommandsStandard::isQuit() &&
                 (TimeKeeper::getCurrent() - start < maxProcessingTime))
         {
             // process one event
-            doEvent(display);
+            bool anyEvent = doEvent(display);
+            if (!anyEvent)
+                break;
         }
     }
 }

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -1623,7 +1623,6 @@ int curlProgressFunc(void* UNUSED(clientp),
 
     // abort the download?
     BzfEvent event;
-    if (display->isEventPending())
     {
         if (display->peekEvent(event))
         {

--- a/src/platform/SDL2Display.cxx
+++ b/src/platform/SDL2Display.cxx
@@ -110,6 +110,7 @@ bool SDLDisplay::peekEvent(BzfEvent& _event) const
      * SDL_PollEvent does the job
      */
     SDL_Event event;
+    SDL_PumpEvents();
     if (SDL_PeepEvents(&event, 1, SDL_PEEKEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT)
             <= 0)
         return false;


### PR DESCRIPTION
isEventPending is not really needed on the event loop, as there is already a check in the peekEvent for no events.
On the curl loop, the other place where  isEventPending is present, added a check for getEvent not returning any event.

With these changes, SDL_PollEvents(NULL) is never called