### PR TITLE
Fix incorrect rotation for API custom zones

### DIFF
--- a/Xcode/BZFlag.xcodeproj/project.pbxproj
+++ b/Xcode/BZFlag.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		C353B1DB1AE23A0C00C5AED5 /* CustomZoneSample.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = C353B1D71AE239CC00C5AED5 /* CustomZoneSample.dylib */; };
 		C353B1E71AE23CA900C5AED5 /* CustomZoneSample.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C353B1E01AE23C8100C5AED5 /* CustomZoneSample.cpp */; };
 		C39F69371E3D3E8100132C55 /* customPollTypeSample.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = C333EFC91E2B9F0800B4B182 /* customPollTypeSample.dylib */; };
+		C3C1D9ED27F58DD7007149B6 /* CustomZoneSample.bzw in CopyFiles */ = {isa = PBXBuildFile; fileRef = C353B1E81AE2489900C5AED5 /* CustomZoneSample.bzw */; };
 		C3DE232E21E2FBDD0081B64E /* libplugin_utils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0394E895167B2513007F4035 /* libplugin_utils.a */; };
 		DF28982B16B4F5AE006C78AC /* ShotManager.cxx in Sources */ = {isa = PBXBuildFile; fileRef = DF28982916B4F5AE006C78AC /* ShotManager.cxx */; };
 /* End PBXBuildFile section */
@@ -963,6 +964,16 @@
 			dstSubfolderSpec = 10;
 			files = (
 				034E307B1B0C945000E7DDE2 /* SDL2.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C3C1D9EC27F58DC9007149B6 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+				C3C1D9ED27F58DD7007149B6 /* CustomZoneSample.bzw in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4753,6 +4764,7 @@
 				C353B1D31AE239CC00C5AED5 /* Sources */,
 				C353B1D41AE239CC00C5AED5 /* Frameworks */,
 				C353B1D51AE239CC00C5AED5 /* Headers */,
+				C3C1D9EC27F58DC9007149B6 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/plugins/CustomZoneSample/CustomZoneSample.bzw
+++ b/plugins/CustomZoneSample/CustomZoneSample.bzw
@@ -11,7 +11,7 @@ box
 end
 
 box
-    pos 0 0 -1
+    pos 0 -40 -1
     size 20 10 0.1
     rot 90
 end
@@ -30,7 +30,7 @@ msgzone
 end
 
 msgzone
-    pos 0 0 0
+    pos 0 -40 0
     size 20 10 0.1
     rot 90
     message "You entered a 90 degree rotated rectangular zone with the GM flag! I'll take it from you!"

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -3114,15 +3114,10 @@ BZF_API bool bz_CustomZoneObject::pointInZone(float pos[3])
 {
     if (box)
     {
-        if (rotation == 0 || rotation == 180)
+        if (fmod(rotation, 90) == 0)
         {
             if (pos[0] > xMax || pos[0] < xMin) return false;
             if (pos[1] > yMax || pos[1] < yMin) return false;
-        }
-        else if (rotation == 90 || rotation == 270)
-        {
-            if (pos[1] > xMax || pos[1] < xMin) return false;
-            if (pos[0] > yMax || pos[0] < yMin) return false;
         }
         else // the box is rotated, maths is needed
         {
@@ -3220,7 +3215,7 @@ BZF_API void bz_CustomZoneObject::handleDefaultOptions(bz_CustomMapObjectInfo *d
 
                 bz_debugMessagef(0,
                                  "WARNING: The \"BBOX\" attribute has been deprecated. Please use the `position` and `size` attributes instead:");
-                bz_debugMessagef(0, "  position %.0f %.0f %.0f", (xMax + xMin), (yMax + yMin), zMin);
+                bz_debugMessagef(0, "  position %.0f %.0f %.0f", ((xMax + xMin) / 2), ((yMax + yMin) / 2), zMin);
                 bz_debugMessagef(0, "  size %.0f %.0f %.0f", ((xMax - xMin) / 2), ((yMax - yMin) / 2), (zMax - zMin));
             }
             else if ( key == "CYLINDER" && nubs->size() > 5)
@@ -3272,13 +3267,24 @@ BZF_API void bz_CustomZoneObject::handleDefaultOptions(bz_CustomMapObjectInfo *d
     {
         if (box)
         {
-            xMin = _pos[0] - _size[0];
-            xMax = _pos[0] + _size[0];
-            yMin = _pos[1] - _size[1];
-            yMax = _pos[1] + _size[1];
             zMin = _pos[2];
             zMax = _pos[2] + _size[2];
             rotation  = (_rotation > 0 && _rotation < 360) ? _rotation : 0;
+
+            if (rotation == 0 || rotation == 180)
+            {
+                xMin = _pos[0] - _size[0];
+                xMax = _pos[0] + _size[0];
+                yMin = _pos[1] - _size[1];
+                yMax = _pos[1] + _size[1];
+            }
+            else
+            {
+                xMin = _pos[0] - _size[1];
+                xMax = _pos[0] + _size[1];
+                yMin = _pos[1] - _size[0];
+                yMax = _pos[1] + _size[0];
+            }
         }
         else
         {

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -3271,19 +3271,19 @@ BZF_API void bz_CustomZoneObject::handleDefaultOptions(bz_CustomMapObjectInfo *d
             zMax = _pos[2] + _size[2];
             rotation  = (_rotation > 0 && _rotation < 360) ? _rotation : 0;
 
-            if (rotation == 0 || rotation == 180)
-            {
-                xMin = _pos[0] - _size[0];
-                xMax = _pos[0] + _size[0];
-                yMin = _pos[1] - _size[1];
-                yMax = _pos[1] + _size[1];
-            }
-            else
+            if (rotation == 90 || rotation == 270)
             {
                 xMin = _pos[0] - _size[1];
                 xMax = _pos[0] + _size[1];
                 yMin = _pos[1] - _size[0];
                 yMax = _pos[1] + _size[0];
+            }
+            else
+            {
+                xMin = _pos[0] - _size[0];
+                xMax = _pos[0] + _size[0];
+                yMin = _pos[1] - _size[1];
+                yMax = _pos[1] + _size[1];
             }
         }
         else


### PR DESCRIPTION
After chatting with tupone on IRC, he pointed out that the logic for determining whether a point was inside of a custom zone was incorrect when it was rotated 90 or 270 degrees. Originally when I tested this code, I made the mistake of testing it when an object at coordinates (0,0) so it worked just fine; but if the object as anywhere but the origin, it'd be incorrect. Additionally, the debug message for BBOX conversion outputted an incorrect position; that has also been fixed.
