### PR TITLE
add missing bzfsAPI function bz_getPlayerCurrentState()

### DIFF
--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1556,6 +1556,7 @@ BZF_API bool bz_isPlayerPaused( int playerID );
 BZF_API double bz_getPausedTime( int playerID );
 BZF_API double bz_getIdleTime( int playerID );
 
+BZF_API bool bz_getPlayerCurrentState(int playerID, bz_PlayerUpdateState &state);
 BZF_API bz_eTeamType bz_getPlayerTeam(int playerID);
 BZF_API const char* bz_getPlayerCallsign(int playerID);
 BZF_API const char* bz_getPlayerMotto(int playerID);

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1232,6 +1232,18 @@ BZF_API double bz_getIdleTime( int playerID )
     return otherData->player.getIdleTime();
 }
 
+BZF_API bool bz_getPlayerCurrentState(int playerID, bz_PlayerUpdateState &state)
+{
+    GameKeeper::Player *player = GameKeeper::Player::getPlayerByIndex(playerID);
+
+    if (!player)
+        return false;
+
+    playerStateToAPIState(state, player->lastState);
+
+    return true;
+}
+
 BZF_API bz_eTeamType bz_getPlayerTeam( int playerID )
 {
     GameKeeper::Player *player = GameKeeper::Player::getPlayerByIndex(playerID);


### PR DESCRIPTION
Committer: Devin Delong <devindelong@protonmail.com>

bz_getPlayerCurrentState() is documented on bzflag.org, but I could not find it in code. Return value was changed to bool.