### PR TITLE
Fix blocking time calculation

### DIFF
--- a/src/bzadmin/ServerLink.cxx
+++ b/src/bzadmin/ServerLink.cxx
@@ -541,7 +541,7 @@ int ServerLink::read(uint16_t& code, uint16_t& len, void* msg, int blockTime)
     // block for specified period.  default is no blocking (polling)
     struct timeval timeout;
     timeout.tv_sec = blockTime / 1000;
-    timeout.tv_usec = blockTime - 1000 * timeout.tv_sec;
+    timeout.tv_usec = 1000 * (blockTime % 1000);
 
     // only check server
     fd_set read_set;

--- a/src/bzflag/ServerLink.cxx
+++ b/src/bzflag/ServerLink.cxx
@@ -541,7 +541,7 @@ int ServerLink::read(uint16_t& code, uint16_t& len, void* msg, int blockTime)
     // block for specified period.  default is no blocking (polling)
     struct timeval timeout;
     timeout.tv_sec = blockTime / 1000;
-    timeout.tv_usec = blockTime - 1000 * timeout.tv_sec;
+    timeout.tv_usec = 1000 * (blockTime % 1000);
 
     // only check server
     fd_set read_set;


### PR DESCRIPTION
Fix for issue #313. This corrects the calculation from block time to a `struct timeval` from milliseconds to microseconds.