### PR TITLE
Fix mouse wheel firing causing MG to endlessly fire

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,9 @@
 BZFlag 2.4.25
 -------------
 
+* Fix Machine Gun firing continuously when mouse wheel is bound to fire
+    - Scott Wichser
+
 
 BZFlag 2.4.24  "Thank you for your input" (2022-03-08)
 ------------------------------------------------------

--- a/src/platform/SDL2Display.cxx
+++ b/src/platform/SDL2Display.cxx
@@ -16,7 +16,7 @@
 // System includes
 #include <vector>
 
-SDLDisplay::SDLDisplay()
+SDLDisplay::SDLDisplay() : mouseWheelStopEvent(SDL_RegisterEvents(1))
 {
     if (SDL_VideoInit(NULL) < 0)
     {
@@ -78,9 +78,6 @@ SDLDisplay::SDLDisplay()
 
     // register modes
     initResolutions(_resolutions, _numResolutions, defaultResolutionIndex);
-
-    // Register a user event so we can trigger a KeyUp event for the mouse wheel
-    mouseWheelStopEvent = SDL_RegisterEvents(1);
 }
 
 SDLDisplay::~SDLDisplay()

--- a/src/platform/SDL2Display.cxx
+++ b/src/platform/SDL2Display.cxx
@@ -407,7 +407,8 @@ bool SDLDisplay::setupEvent(BzfEvent& _event, const SDL_Event& event) const
 
     // Specifically handle our custom mouse wheel event here to trigger a KeyUp event, fixing the
     // issue where MG would fire endlessly.
-    if (event.type == mouseWheelStopEvent) {
+    if (event.type == mouseWheelStopEvent)
+    {
         _event.type   = BzfEvent::KeyUp;
         _event.keyDown.ascii = 0;
         _event.keyDown.shift = 0;

--- a/src/platform/SDL2Display.h
+++ b/src/platform/SDL2Display.h
@@ -47,7 +47,7 @@ public:
     };
     void getModState(bool &shift, bool &control, bool &alt);
 private:
-    Uint32 mouseWheelStopEvent;
+    const Uint32 mouseWheelStopEvent;
     bool setupEvent(BzfEvent&, const SDL_Event&) const;
     bool doSetResolution(int)
     {

--- a/src/platform/SDL2Display.h
+++ b/src/platform/SDL2Display.h
@@ -47,6 +47,7 @@ public:
     };
     void getModState(bool &shift, bool &control, bool &alt);
 private:
+    Uint32 mouseWheelStopEvent;
     bool setupEvent(BzfEvent&, const SDL_Event&) const;
     bool doSetResolution(int)
     {


### PR DESCRIPTION
Our mouse wheel event only triggered a KeyDown event. When mouse wheel was mapped to fire, this would cause MG to fire endlessly. This change adds a custom user event that gets pushed to SDL when a mouse wheel event is triggered. When this custom event is processed, we trigger a KeyUp event for the same mouse wheel direction.