### PR TITLE
use the new MIME interface for cURL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -300,7 +300,7 @@ AC_CHECK_LIB(cares, ares_library_init, AC_DEFINE([HAVE_ARES_LIBRARY_INIT],[1],[D
 
 dnl detect a usable system curl library
 LIBCURL=""
-LIBCURL_CHECK_CONFIG
+LIBCURL_CHECK_CONFIG(, 7.55.0)
 AC_MSG_CHECKING(checking for curl library)
 if test "x$LIBCURL" = "x" ; then
     AC_MSG_ERROR([working curl library was not found])

--- a/include/cURLManager.h
+++ b/include/cURLManager.h
@@ -43,12 +43,11 @@ public:
     void setTimeout(long timeout);
     void setNoBody();
     void setGetMode();
-    void setHTTPPostMode();
     void setPostMode(std::string postData);
     void setRequestFileTime(bool request);
     void setURL(const std::string &url);
     void setURLwithNonce(const std::string &url);
-    void setProgressFunction(curl_progress_callback func, const void* data);
+    void setProgressFunction(curl_xferinfo_callback func, const void* data);
     void setTimeCondition(timeCondition condition, time_t &t);
     void setInterface(const std::string &interfaceIP);
     void setUserAgent(const std::string &userAgent);
@@ -57,7 +56,7 @@ public:
     void addFormData(const char *key, const char *value);
 
     bool getFileTime(time_t &t);
-    bool getFileSize(double &size);
+    bool getFileSize(int    &size);
 
     virtual void collectData(char *ptr, int len);
     virtual void finalization(char *data, unsigned int length, bool good);
@@ -83,9 +82,6 @@ private:
     std::string   interfaceIP;
     std::string   userAgent;
     std::string   postData;
-
-    struct curl_httppost* formPost;
-    struct curl_httppost* formLast;
 
     static void   setup();
 

--- a/src/bzflag/NewVersionMenu.cxx
+++ b/src/bzflag/NewVersionMenu.cxx
@@ -142,11 +142,11 @@ void NewVersionMenu::execute()
 void NewVersionMenu::collectData(char* ptr, int len)
 {
     char buffer[128];
-    double size = 0;
+    int size = 0;
     getFileSize(size);
     cURLManager::collectData(ptr, len);
     byteTransferred += len;
-    snprintf(buffer, 128, "Downloading update: %d/%d KB", byteTransferred/1024, (int)size/1024);
+    snprintf(buffer, 128, "Downloading update: %d/%d KB", byteTransferred/1024, size/1024);
     ((HUDuiLabel*)status)->setString(buffer);
 }
 

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -1614,8 +1614,8 @@ static bool isCached(char *hexDigest)
 
 
 int curlProgressFunc(void* UNUSED(clientp),
-                     double dltotal, double dlnow,
-                     double UNUSED(ultotal), double UNUSED(ulnow))
+                     curl_off_t dltotal, curl_off_t dlnow,
+                     curl_off_t UNUSED(ultotal), curl_off_t UNUSED(ulnow))
 {
     // FIXME: beaucoup cheeze here in the aborting style
     //    we should be using async dns and multi-curl


### PR DESCRIPTION
Is not tested. Only compiled.
There is no call of that code on the tree, and is not exported.
But maybe in the future could be.
