### PR TITLE
Adding common.h include where missing

### DIFF
--- a/include/AccessList.h
+++ b/include/AccessList.h
@@ -13,6 +13,10 @@
 #ifndef ACCESS_LIST_H
 #define ACCESS_LIST_H
 
+// 1st
+#include "common.h"
+
+// System headers
 #include <stdio.h>
 #include <string>
 #include <vector>

--- a/include/AnsiCodes.h
+++ b/include/AnsiCodes.h
@@ -13,7 +13,13 @@
 #ifndef _ANSI_CODES_H_
 #define _ANSI_CODES_H_
 
+// 1st
+#include "common.h"
+
+// System headers
 #include <string>
+
+// Common headers
 #include "TextUtils.h"
 
 // Escape character to begin ANSI codes

--- a/include/ArcObstacle.h
+++ b/include/ArcObstacle.h
@@ -17,9 +17,13 @@
 #ifndef BZF_ARC_OBSTACLE_H
 #define BZF_ARC_OBSTACLE_H
 
-#include "common.h"
-#include <string>
+// Inherits from
 #include "Obstacle.h"
+
+// System headers
+#include <string>
+
+// Common headers
 #include "MeshObstacle.h"
 #include "MeshTransform.h"
 #include "BzMaterial.h"

--- a/include/AutoCompleter.h
+++ b/include/AutoCompleter.h
@@ -13,6 +13,10 @@
 #ifndef AUTOCOMPLETER_H
 #define AUTOCOMPLETER_H
 
+// 1st
+#include "common.h"
+
+// System headers
 #include <string>
 #include <vector>
 

--- a/include/CacheManager.h
+++ b/include/CacheManager.h
@@ -13,6 +13,9 @@
 #ifndef CACHE_MANAGER_H
 #define CACHE_MANAGER_H
 
+// 1st
+#include "common.h"
+
 #include <time.h>
 #include <string>
 #include <vector>

--- a/include/CallbackList.h
+++ b/include/CallbackList.h
@@ -13,13 +13,13 @@
 #ifndef BZF_CALLBACK_LIST_H
 #define BZF_CALLBACK_LIST_H
 
+// 1st
+#include "common.h"
+
 // system headers
 #include <utility>
 #include <list>
 #include <map>
-
-// local implementation headers
-#include "common.h"
 
 template <class F>
 class CallbackList

--- a/include/ConfigFileManager.h
+++ b/include/ConfigFileManager.h
@@ -13,8 +13,11 @@
 #ifndef BZF_CONFIG_FILE_MANAGER_H
 #define BZF_CONFIG_FILE_MANAGER_H
 
-#include <string>
+// Inherits from
 #include "Singleton.h"
+
+// System interfaces
+#include <string>
 
 #define CFGMGR (ConfigFileManager::instance())
 

--- a/include/FontManager.h
+++ b/include/FontManager.h
@@ -13,11 +13,15 @@
 #ifndef _FONT_MANAGER_H_
 #define _FONT_MANAGER_H_
 
+// Inherits from
+#include "Singleton.h"
+
+// System interfaces
 #include <map>
 #include <string>
 #include <vector>
 
-#include "Singleton.h"
+// Common interfaces
 #include "bzfgl.h"
 #include "AnsiCodes.h"
 

--- a/include/MeshTransform.h
+++ b/include/MeshTransform.h
@@ -13,7 +13,10 @@
 #ifndef _TRANSFORM_H_
 #define _TRANSFORM_H_
 
+//1st
+#include "common.h"
 
+// System headers
 #include <string>
 #include <vector>
 #include <iostream>

--- a/include/ObstacleSceneNodeGenerator.h
+++ b/include/ObstacleSceneNodeGenerator.h
@@ -13,6 +13,9 @@
 #ifndef __OBSTACLESCENENODEGENERATOR_H__
 #define __OBSTACLESCENENODEGENERATOR_H__
 
+//1st
+#include "common.h"
+
 class WallSceneNode;
 
 class ObstacleSceneNodeGenerator

--- a/include/ParseColor.h
+++ b/include/ParseColor.h
@@ -13,6 +13,8 @@
 #ifndef _PARSE_COLOR_H_
 #define _PARSE_COLOR_H_
 
+// 1st
+#include "common.h"
 
 #include <string>
 #include <iostream>

--- a/include/ShotUpdate.h
+++ b/include/ShotUpdate.h
@@ -23,11 +23,13 @@
 #ifndef BZF_SHOT_UPDATE_H
 #define BZF_SHOT_UPDATE_H
 
+// 1st
+#include "common.h"
+
 // system headers
 #include <math.h>
 
 // local implementation headers
-#include "common.h"
 #include "Address.h"
 #include "Flag.h"
 

--- a/include/Singleton.h
+++ b/include/Singleton.h
@@ -13,6 +13,9 @@
 #ifndef __SINGLETON_H__
 #define __SINGLETON_H__
 
+// 1st
+#include "common.h"
+
 /* Singleton template class
  *
  * This template is based on an implementation suggested by Martin York in
@@ -29,6 +32,7 @@
  * The class will need to provide an accessible default constructor
  *
  */
+
 template < typename T >
 class Singleton
 {

--- a/include/TextureManager.h
+++ b/include/TextureManager.h
@@ -12,9 +12,14 @@
 #ifndef _TEXTURE_MANAGER_H
 #define _TEXTURE_MANAGER_H
 
+// 1st
+#include "common.h"
+
+// System headers
 #include <string>
 #include <map>
 
+// Common headers
 #include "OpenGLTexture.h"
 #include "Singleton.h"
 

--- a/include/WorldEventManager.h
+++ b/include/WorldEventManager.h
@@ -21,10 +21,15 @@
 #ifndef WORLD_EVENT_MANAGER_H
 #define WORLD_EVENT_MANAGER_H
 
+// 1st
+#include "common.h"
+
+// System headers
 #include <map>
 #include <vector>
 #include <algorithm>
 
+// Common headers
 #include "bzfsAPI.h"
 
 // event handler callback

--- a/include/bzfSDL.h
+++ b/include/bzfSDL.h
@@ -13,6 +13,9 @@
 #ifndef __BZFSDL_H__
 #define __BZFSDL_H__
 
+// 1st
+#include "common.h"
+
 /** this file contains headers necessary for SDL */
 
 #ifdef HAVE_SDL2_SDL_H

--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -15,6 +15,9 @@
 #ifndef _BZFS_API_H_
 #define _BZFS_API_H_
 
+// 1st
+#include "common.h"
+
 /* system interface headers */
 #include <string>
 #include <cstring>

--- a/include/bzglob.h
+++ b/include/bzglob.h
@@ -13,6 +13,9 @@
 #ifndef BZ_GLOB_H
 #define BZ_GLOB_H
 
+// 1st
+#include "common.h"
+
 #include <string>
 
 extern bool glob_match(const char* pattern, const char* string);

--- a/include/bzsignal.h
+++ b/include/bzsignal.h
@@ -13,9 +13,8 @@
 #ifndef __BZSIGNAL_H__
 #define __BZSIGNAL_H__
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+// 1st
+#include "common.h"
 
 #include <signal.h>
 

--- a/include/vectors.h
+++ b/include/vectors.h
@@ -13,7 +13,10 @@
 #ifndef VECTORS_H
 #define VECTORS_H
 
+// 1st
+#include "common.h"
 
+// System headers
 #include <math.h>
 #include <stdio.h>
 #include <string>

--- a/include/vectors_old.h
+++ b/include/vectors_old.h
@@ -13,6 +13,10 @@
 #ifndef __VECTOR_MATH_H__
 #define __VECTOR_MATH_H__
 
+// 1st
+#include "common.h"
+
+// System headers
 #include <string.h>
 
 // vectors implemented as arrays

--- a/include/version.h
+++ b/include/version.h
@@ -13,7 +13,8 @@
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#include "config.h"
+// 1st
+#include "common.h"
 
 #ifndef BZ_CONFIG_DIR_VERSION
 #define BZ_CONFIG_DIR_VERSION   "2.4"


### PR DESCRIPTION
include common.h should be the first (direct or indirectly) include on each compilation unit. (see DEVINFO)
Added, where missing on the include/* files

tried on linux. Need a test on windows and Mac to publish