### PR TITLE
Request an authentication token only at join, and using the GETTOKEN action instead of the LIST action.

### DIFF
--- a/MSVC/build/game.vcxproj
+++ b/MSVC/build/game.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="..\..\src\game\PhysicsDriver.cxx" />
     <ClCompile Include="..\..\src\game\PlayerInfo.cxx" />
     <ClCompile Include="..\..\src\game\Ray.cxx" />
+    <ClCompile Include="..\..\src\game\ServerAuth.cxx" />
     <ClCompile Include="..\..\src\game\ServerItem.cxx" />
     <ClCompile Include="..\..\src\game\ServerList.cxx" />
     <ClCompile Include="..\..\src\game\ServerListCache.cxx" />
@@ -184,6 +185,7 @@
     <ClInclude Include="..\..\include\PhysicsDriver.h" />
     <ClInclude Include="..\..\include\PlayerInfo.h" />
     <ClInclude Include="..\..\include\Ray.h" />
+    <ClInclude Include="..\..\include\ServerAuth.h" />
     <ClInclude Include="..\..\include\ServerItem.h" />
     <ClInclude Include="..\..\include\ServerList.h" />
     <ClInclude Include="..\..\include\ServerListCache.h" />

--- a/MSVC/build/game.vcxproj.filters
+++ b/MSVC/build/game.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClCompile Include="..\..\src\game\Frustum.cxx">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\game\ServerAuth.cxx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\BzMaterial.h">
@@ -112,6 +115,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\StartupInfo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\ServerAuth.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Xcode/BZFlag.xcodeproj/project.pbxproj
+++ b/Xcode/BZFlag.xcodeproj/project.pbxproj
@@ -529,6 +529,7 @@
 		C38E766527F9062B00EC312C /* CustomZoneSample.bzw in Copy Files (1 item) */ = {isa = PBXBuildFile; fileRef = C353B1E81AE2489900C5AED5 /* CustomZoneSample.bzw */; };
 		C39F69371E3D3E8100132C55 /* customPollTypeSample.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = C333EFC91E2B9F0800B4B182 /* customPollTypeSample.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C3DE232E21E2FBDD0081B64E /* libplugin_utils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0394E895167B2513007F4035 /* libplugin_utils.a */; };
+		D21A35892BFAA6BD001A28EB /* ServerAuth.cxx in Sources */ = {isa = PBXBuildFile; fileRef = D21A35882BFAA6BD001A28EB /* ServerAuth.cxx */; };
 		D2B721C92BFAA226007126EE /* mathRoutine.cxx in Sources */ = {isa = PBXBuildFile; fileRef = D2B721C82BFAA225007126EE /* mathRoutine.cxx */; };
 		DF28982B16B4F5AE006C78AC /* ShotManager.cxx in Sources */ = {isa = PBXBuildFile; fileRef = DF28982916B4F5AE006C78AC /* ShotManager.cxx */; };
 /* End PBXBuildFile section */
@@ -1814,6 +1815,8 @@
 		C353B1E01AE23C8100C5AED5 /* CustomZoneSample.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CustomZoneSample.cpp; sourceTree = "<group>"; };
 		C353B1E81AE2489900C5AED5 /* CustomZoneSample.bzw */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CustomZoneSample.bzw; sourceTree = "<group>"; };
 		C353B1E91AE2490D00C5AED5 /* flagStay.bzw */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = flagStay.bzw; sourceTree = "<group>"; };
+		D21A35872BFAA6AE001A28EB /* ServerAuth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServerAuth.h; sourceTree = "<group>"; };
+		D21A35882BFAA6BD001A28EB /* ServerAuth.cxx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ServerAuth.cxx; sourceTree = "<group>"; };
 		D2B721C72BFAA1E1007126EE /* mathRoutine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mathRoutine.h; sourceTree = "<group>"; };
 		D2B721C82BFAA225007126EE /* mathRoutine.cxx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mathRoutine.cxx; sourceTree = "<group>"; };
 		DF28982916B4F5AE006C78AC /* ShotManager.cxx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShotManager.cxx; sourceTree = "<group>"; };
@@ -2347,6 +2350,7 @@
 				0305D5D9166C9DAE00557FC4 /* SceneDatabase.h */,
 				0305D5DA166C9DAE00557FC4 /* SceneNode.h */,
 				0305D5DB166C9DAE00557FC4 /* SceneRenderer.h */,
+				D21A35872BFAA6AE001A28EB /* ServerAuth.h */,
 				0305D5DC166C9DAE00557FC4 /* ServerItem.h */,
 				0305D5DD166C9DAE00557FC4 /* ServerList.h */,
 				0305D5DE166C9DAE00557FC4 /* ServerListCache.h */,
@@ -2858,6 +2862,7 @@
 				0355447B166C846F008806E9 /* PlayerInfo.cxx */,
 				0355447C166C846F008806E9 /* Ray.cxx */,
 				0355447D166C846F008806E9 /* README */,
+				D21A35882BFAA6BD001A28EB /* ServerAuth.cxx */,
 				0355447E166C846F008806E9 /* ServerItem.cxx */,
 				0355447F166C846F008806E9 /* ServerList.cxx */,
 				03554480166C846F008806E9 /* ServerListCache.cxx */,
@@ -5070,6 +5075,7 @@
 				0357A80E1670B2090056C938 /* PhysicsDriver.cxx in Sources */,
 				0357A80F1670B2090056C938 /* PlayerInfo.cxx in Sources */,
 				0357A8101670B2090056C938 /* Ray.cxx in Sources */,
+				D21A35892BFAA6BD001A28EB /* ServerAuth.cxx in Sources */,
 				0357A8111670B2090056C938 /* ServerItem.cxx in Sources */,
 				0357A8121670B2090056C938 /* ServerList.cxx in Sources */,
 				0357A8131670B2090056C938 /* ServerListCache.cxx in Sources */,

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -102,6 +102,7 @@ noinst_HEADERS =			\
 	SceneDatabase.h			\
 	SceneNode.h			\
 	SceneRenderer.h			\
+	ServerAuth.h			\
 	ServerItem.h			\
 	ServerList.h			\
 	ServerListCache.h		\

--- a/include/ServerAuth.h
+++ b/include/ServerAuth.h
@@ -1,0 +1,38 @@
+/* bzflag
+ * Copyright (c) 1993-2024 Tim Riker
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef BZF_SERVERAUTH_H
+#define BZF_SERVERAUTH_H
+
+#include "common.h"
+
+/* system interface headers */
+#include <vector>
+
+/* common interface headers */
+#include "StartupInfo.h"
+#include "cURLManager.h"
+
+class ServerAuth : cURLManager
+{
+public:
+    ServerAuth();
+    virtual ~ServerAuth();
+
+    void requestToken(StartupInfo *info);
+    void finalization(char *data, unsigned int length, bool good);
+
+private:
+    StartupInfo *startupInfo;
+};
+
+#endif // BZF_SERVERAUTH_H

--- a/include/cURLManager.h
+++ b/include/cURLManager.h
@@ -46,7 +46,6 @@ public:
     void setPostMode(std::string postData);
     void setRequestFileTime(bool request);
     void setURL(const std::string &url);
-    void setURLwithNonce(const std::string &url);
     void setProgressFunction(curl_xferinfo_callback func, const void* data);
     void setTimeCondition(timeCondition condition, time_t &t);
     void setInterface(const std::string &interfaceIP);

--- a/src/bzfs/ListServerConnection.cxx
+++ b/src/bzfs/ListServerConnection.cxx
@@ -43,7 +43,7 @@ ListServerLink::ListServerLink(std::string listServerURL,
     std::string bzfsUserAgent = "bzfs ";
     bzfsUserAgent     += getAppVersion();
 
-    setURLwithNonce(listServerURL);
+    setURL(listServerURL);
     setUserAgent(bzfsUserAgent);
     setTimeout(10);
 

--- a/src/common/cURLManager.cxx
+++ b/src/common/cURLManager.cxx
@@ -186,14 +186,6 @@ void cURLManager::setURL(const std::string &url)
         logDebugMessage(1,"CURLOPT_URL error %d : %s\n", result, errorBuffer);
 }
 
-void cURLManager::setURLwithNonce(const std::string &url)
-{
-    // only the default list server is known to support the nonce parameter
-    const std::string nonce = (strcasecmp(url.c_str(), DefaultListServerURL) == 0) ? TextUtils::format("?nocache=%lu",
-                              time(0)) : "";
-    setURL(url + nonce);
-}
-
 void cURLManager::setProgressFunction(curl_xferinfo_callback func, const void* data)
 {
     CURLcode result;

--- a/src/game/Makefile.am
+++ b/src/game/Makefile.am
@@ -26,6 +26,7 @@ libGame_la_SOURCES =			\
 	PlayerInfo.cxx			\
 	Ray.cxx				\
 	ServerItem.cxx			\
+	ServerAuth.cxx			\
 	ServerList.cxx			\
 	ServerListCache.cxx		\
 	StartupInfo.cxx			\

--- a/src/game/ServerAuth.cxx
+++ b/src/game/ServerAuth.cxx
@@ -1,0 +1,111 @@
+/* bzflag
+ * Copyright (c) 1993-2024 Tim Riker
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/* interface header */
+#include "ServerAuth.h"
+
+/* system headers */
+#include <cstring>
+
+/* common implementation headers */
+#include "TextUtils.h"
+#include "ErrorHandler.h"
+
+ServerAuth::ServerAuth()
+{
+}
+
+ServerAuth::~ServerAuth()
+{
+}
+
+void ServerAuth::requestToken(StartupInfo *info)
+{
+    startupInfo = info;
+
+    std::string url = info->listServerURL;
+
+    std::string msg = "action=GETTOKEN&callsign=";
+    msg     += TextUtils::url_encode(info->callsign);
+    msg     += "&password=";
+    msg     += TextUtils::url_encode(info->password);
+    if (info->serverName[0] != '\0')
+    {
+        msg += "&nameport=";
+        msg += info->serverName;
+        msg += ':';
+        msg += std::to_string(info->serverPort);
+    }
+    setPostMode(msg);
+    setURL(url);
+    addHandle();
+}
+
+void ServerAuth::finalization(char *_data, unsigned int length, bool good)
+{
+    if (good)
+    {
+        char *base = (char *)_data;
+        char *endS = base + length;
+        const char tokenIdentifier[]   = "TOKEN: ";
+        const char noTokenIdentifier[] = "NOTOK: ";
+        const char errorIdentifier[]   = "ERROR: ";
+        const char noticeIdentifier[]  = "NOTICE: ";
+
+        while (base < endS)
+        {
+            // find next newline
+            char* scan = base;
+            while (scan < endS && *scan != '\n')
+                scan++;
+
+            // if no newline then no more complete replies
+            if (scan >= endS)
+                break;
+            *scan++ = '\0';
+
+            // look for TOKEN: and save token if found also look for NOTOK:
+            // and record "badtoken" into the token string and print an
+            // error
+            if (strncmp(base, tokenIdentifier, strlen(tokenIdentifier)) == 0)
+            {
+                strncpy(startupInfo->token, (char *)(base + strlen(tokenIdentifier)),
+                        TokenLen - 1);
+                startupInfo->token[TokenLen - 1] = '\0';
+#ifdef DEBUG
+                std::vector<std::string> args;
+                args.push_back(startupInfo->token);
+                printError("got token: {1}", &args);
+#endif
+            }
+            else if (!strncmp(base, noTokenIdentifier,
+                              strlen(noTokenIdentifier)))
+            {
+                printError("ERROR: did not get token:");
+                printError(base);
+                strcpy(startupInfo->token, "badtoken\0");
+            }
+            else if (!strncmp(base, errorIdentifier, strlen(errorIdentifier)))
+            {
+                printError(base);
+                strcpy(startupInfo->token, "badtoken\0");
+            }
+            else if (!strncmp(base, noticeIdentifier, strlen(noticeIdentifier)))
+                printError(base);
+
+            // next reply
+            base = scan;
+        }
+    }
+    else
+        strcpy(startupInfo->token, "badtoken\0");
+}


### PR DESCRIPTION
Previously, we've used the LIST action to request a player authentication token. This was often wasteful because it requested the entire list of servers as well. We *could* use the token that was provided along with the server list when joining a game server, so it did at times consolidate two requests down to one. However, we're now aiming to restrict a game token to a specific game server host/port instead of the player's IP address so that we can handle CGNAT.

This change causes the token to only be requested during the join process. Additionally, when paired with the new [bzfls3](https://github.com/BZFlag-Dev/bzflag-bzfls3), no token will be generated during the LIST action.