### PR TITLE
Add support for pasting text from the clipboard into text inputs.

### DIFF
--- a/include/PlatformFactory.h
+++ b/include/PlatformFactory.h
@@ -19,6 +19,8 @@
 
 #include "common.h"
 
+#include <string>
+
 class BzfDisplay;
 class BzfVisual;
 class BzfWindow;
@@ -36,6 +38,7 @@ public:
     virtual BzfVisual*   createVisual(const BzfDisplay*) = 0;
     virtual BzfWindow*   createWindow(const BzfDisplay*, BzfVisual*) = 0;
     virtual BzfJoystick* createJoystick();
+    virtual std::string  getClipboard() = 0;
 
     static PlatformFactory* getInstance();
     static BzfMedia*        getMedia();

--- a/src/bzflag/HUDuiTypeIn.h
+++ b/src/bzflag/HUDuiTypeIn.h
@@ -38,10 +38,10 @@ public:
     ~HUDuiTypeIn();
 
     void        setObfuscation(bool on);
-    int         getMaxLength() const;
+    size_t      getMaxLength() const;
     std::string     getString() const;
 
-    void        setMaxLength(int);
+    void        setMaxLength(size_t);
     void        setString(const std::string&);
     void        setEditing(bool _allowEdit);
     void        setColorFunc(TypeInColorFunc func)
@@ -55,9 +55,9 @@ protected:
     void        doRender();
 
 private:
-    int         maxLength;
+    size_t          maxLength;
     std::string     string;
-    int         cursorPos;
+    size_t          cursorPos;
     bool        allowEdit;
     bool        obfuscate;
     TypeInColorFunc colorFunc;

--- a/src/platform/SDLPlatformFactory.cxx
+++ b/src/platform/SDLPlatformFactory.cxx
@@ -65,6 +65,23 @@ BzfJoystick* SdlPlatformFactory::createJoystick()
 {
     return new SDLJoystick;
 }
+
+std::string SdlPlatformFactory::getClipboard()
+{
+    if (SDL_HasClipboardText())
+    {
+        char* clipboard = SDL_GetClipboardText();
+        if (clipboard != nullptr)
+        {
+            const std::string text(clipboard);
+            SDL_free(clipboard);
+            return text;
+        }
+    }
+
+    return std::string();
+}
+
 // Local Variables: ***
 // mode: C++ ***
 // tab-width: 4 ***

--- a/src/platform/SDLPlatformFactory.h
+++ b/src/platform/SDLPlatformFactory.h
@@ -30,6 +30,7 @@ public:
     BzfWindow*        createWindow(const BzfDisplay*, BzfVisual*);
     BzfMedia*     createMedia();
     BzfJoystick*      createJoystick();
+    std::string       getClipboard();
 
 private:
     SdlPlatformFactory(const SdlPlatformFactory&);


### PR DESCRIPTION
This adds support for pasting text into our text fields, both in the menus and the chat input, using Ctrl+V.

Resolves #350