### PR TITLE
Introduce API events & functions to work w/replays

### DIFF
--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -343,6 +343,10 @@ typedef enum
     bz_ePermissionModificationEvent,
     bz_eAllowServerShotFiredEvent,
     bz_ePlayerDeathFinalizedEvent,
+    bz_eReplayRequestedEvent,
+    bz_eReplayLoadedEvent,
+    bz_eRecordingStartedEvent,
+    bz_eRecordingEndedEvent,
     bz_eLastEvent    //this is never used as an event, just show it's the last one
 } bz_eEventType;
 
@@ -488,6 +492,23 @@ typedef struct bz_PlayerUpdateState
 
 
 BZF_API bool bz_freePlayerRecord ( bz_BasePlayerRecord *playerRecord );
+
+// Time utilities
+typedef struct
+{
+    int year;
+    int month;
+    int day;
+    int hour;
+    int minute;
+    int second;
+    int dayofweek;
+    bool daylightSavings;
+} bz_Time;
+
+BZF_API void bz_getLocaltime(bz_Time *ts);
+BZF_API void bz_getUTCtime(bz_Time *ts);
+BZF_API void bz_makeApiTime(time_t time, bz_Time* apiTime);
 
 // event data types
 class BZF_API bz_EventData
@@ -1465,6 +1486,65 @@ public:
     bool customPerm;
 };
 
+class BZF_API bz_RecordingStartedEventData_V1 : public bz_EventData
+{
+public:
+    bz_RecordingStartedEventData_V1() : bz_EventData(bz_eRecordingStartedEvent)
+        , playerID(-1)
+    {}
+
+    int playerID;
+};
+
+class BZF_API bz_RecordingEndedEventData_V1 : public bz_EventData
+{
+public:
+    bz_RecordingEndedEventData_V1() : bz_EventData(bz_eRecordingEndedEvent)
+        , playerID(-1)
+    {}
+
+    int playerID;
+};
+
+class BZF_API bz_ReplayRequestedEventData_V1 : public bz_EventData
+{
+public:
+    bz_ReplayRequestedEventData_V1() : bz_EventData(bz_eReplayRequestedEvent)
+        , playerID(-1)
+        , success(true)
+        , errorMsg("")
+        , filename("")
+    {}
+
+    int playerID;
+    bool success;
+    const char* errorMsg;
+    const char* filename;
+};
+
+class BZF_API bz_ReplayLoadedEventData_V1 : public bz_EventData
+{
+public:
+    bz_ReplayLoadedEventData_V1() : bz_EventData(bz_eReplayLoadedEvent)
+        , filename("")
+        , authorCallsign("")
+        , authorMotto("")
+        , serverVersion("")
+        , seconds(-1.0)
+        , start(NULL)
+        , end(NULL)
+    {}
+
+    const char* filename;
+    const char* authorCallsign;
+    const char* authorMotto;
+    const char* protocol;
+    const char* serverVersion;
+    float seconds;
+    bz_Time* start;
+    bz_Time* end;
+};
+
 // logging
 BZF_API void bz_debugMessage ( int debugLevel, const char* message );
 BZF_API void bz_debugMessagef( int debugLevel, const char* fmt, ... );
@@ -1741,21 +1821,6 @@ BZF_API uint32_t bz_getShotGUID (int fromPlayer, int shotID);
 // geometry utils
 BZF_API bool bz_vectorFromPoints(const float p1[3], const float p2[3], float outVec[3]);
 BZF_API bool bz_vectorFromRotations(const float tilt, const float rotation, float outVec[3]);
-
-typedef struct
-{
-    int year;
-    int month;
-    int day;
-    int hour;
-    int minute;
-    int second;
-    int dayofweek;
-    bool daylightSavings;
-} bz_Time;
-
-BZF_API void bz_getLocaltime(bz_Time *ts);
-BZF_API void bz_getUTCtime(bz_Time *ts);
 
 // BZDB API
 BZF_API double bz_getBZDBDouble ( const char* variable );
@@ -2145,6 +2210,10 @@ BZF_API bz_ApiString bz_filterPath ( const char* path );
 BZF_API bool bz_saveRecBuf( const char * _filename, int seconds  = 0);
 BZF_API bool bz_startRecBuf( void );
 BZF_API bool bz_stopRecBuf( void );
+BZF_API bool bz_isReplayServer( void );
+BZF_API bool bz_loadReplay( const char* _filename, int playerIndex = BZ_SERVERPLAYER );
+BZF_API bool bz_replayExists( const char* _filename );
+BZF_API bool bz_unloadReplay( int playerIndex = BZ_SERVERPLAYER );
 
 // cheap Text Utils
 BZF_API const char *bz_format(const char* fmt, ...);

--- a/src/bzfs/RecordReplay.h
+++ b/src/bzfs/RecordReplay.h
@@ -61,6 +61,7 @@ extern bool init (); // must be done before any players join
 extern bool kill ();
 
 extern bool sendFileList (int playerIndex, const char* options);
+extern bool exists(const char* filename);
 extern bool loadFile (int playerIndex, const char *filename);
 extern bool unloadFile (int playerIndex);
 extern bool play (int playerIndex);

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1936,6 +1936,20 @@ BZF_API void bz_getUTCtime ( bz_Time    *ts )
                         &ts->daylightSavings);
 }
 
+BZF_API void bz_makeApiTime(time_t time, bz_Time* apiTime)
+{
+    tm *tsStruct = gmtime(&time);
+
+    apiTime->year = tsStruct->tm_year;
+    apiTime->month = tsStruct->tm_mon;
+    apiTime->day = tsStruct->tm_mday;
+    apiTime->hour = tsStruct->tm_hour;
+    apiTime->minute = tsStruct->tm_min;
+    apiTime->second = tsStruct->tm_sec;
+    apiTime->dayofweek = tsStruct->tm_wday;
+    apiTime->daylightSavings = tsStruct->tm_isdst;
+}
+
 // info
 BZF_API double bz_getBZDBDouble ( const char* variable )
 {
@@ -4147,6 +4161,35 @@ BZF_API bool bz_stopRecBuf( void )
         return false;
 
     return Record::stop(ServerPlayer);
+}
+
+BZF_API bool bz_isReplayServer( void )
+{
+    return Replay::enabled();
+}
+
+BZF_API bool bz_loadReplay( const char* _filename, int playerIndex )
+{
+    if (!Replay::enabled())
+        return false;
+
+    return Replay::loadFile(playerIndex, _filename);
+}
+
+BZF_API bool bz_replayExists( const char* _filename )
+{
+    if (!Replay::enabled())
+        return false;
+
+    return Replay::exists(_filename);
+}
+
+BZF_API bool bz_unloadReplay( int playerIndex )
+{
+    if (!Replay::enabled())
+        return false;
+
+    return Replay::unloadFile(playerIndex);
 }
 
 BZF_API const char *bz_format(const char* fmt, ...)


### PR DESCRIPTION
## New Functions

### `bool bz_isReplayServer(void)`

Returns true if the current BZFS process runs with the `-replay` flag.

### `bool bz_loadReplay(const char* _filename, int playerIndex = BZ_SERVERPLAYER)`

The BZFS API equivalent of a player running `/replay load`.

### `bool bz_replayExists(const char* _filename)`

Check to see if a given replay filename exists on the server.

### `bool bz_unloadReplay(int playerIndex = BZ_SERVERPLAYER)`

Reset the replay server's status and unload the current replay. This is no slash-command equivalent of this (as far as I know).

## New Server Events

### `bz_eReplayRequestedEvent`

* Dispatched from `Replay::loadFile` -> called from `/replay load`
* This event is triggered before `bz_eReplayLoadedEvent`; any errors that happen in loading replays will be reported here

| Property | Data Type    | Description                                                         |
| -------- | ------------ | ------------------------------------------------------------------- |
| playerID | int          | The player ID that is requesting the replay to be loaded            |
| success  | bool         | Whether the replay was able to load successfully                    |
| errorMsg | const char\* | If there's an error in loading the replay, the details will be here |
| filename | const char\* | The filename of the replay requested                                |

### `bz_eReplayLoadedEvent`

* Dispatched from `Replay::loadFile` -> called from `/replay load`
* This event is only triggered when a file is successfully loaded. If the replay fails to load, this event is never called

| Property       | Data Type    | Description                                                        |
| -------------- | ------------ | ------------------------------------------------------------------ |
| filename       | const char\* | The filename of the replay that's being loaded                     |
| authorCallsign | const char\* | The callsign of the player (or "SERVER") if who started the replay |
| authorMotto    | const char\* | The motto of the author who triggered the recording                |
| protocol       | const char\* | The BZFS protocol version the replay was recorded with             |
| serverVersion  | const char\* | The BZFS version used for the replay                               |
| seconds        | float        | The duration of this recording in seconds                          |
| start          | bz\_Time\*   | Timestamp of when the replay started                               |
| end            | bz\_Time\*   | ...and when it ended                                               |

### `bz_eRecordingStartedEvent`

* Dispatched when a recording starts, i.e. `Record::start`
  * Called during `/record start`
  * Called during `bz_startRecBuf()`

| Property | Data Type | Description                                                               |
| -------- | --------- | ------------------------------------------------------------------------- |
| playerID | int       | The player ID that started the recording or `253` if the server starts it |

### `bz_eRecordingEndedEvent`

* Dispatched when a recording ends, i.e. `Record:stop`
  * Called during `/record stop`
  * Called during `bz_stopRecBuf()`

_Data fields are the same as `bz_eRecordingStartedEvent`_