### PR TITLE
Add functionality to savemsg

### DIFF
--- a/src/bzflag/ControlPanel.cxx
+++ b/src/bzflag/ControlPanel.cxx
@@ -941,8 +941,8 @@ void ControlPanel::saveMessages(const std::string& filename,
     fprintf(file, "----------------------------------------\n\n");
 
     // Iterate through the 'All' tab messages
-    std::deque<ControlPanelMessage>::const_iterator msg = messages[MessageAll].begin()++;
-    for (; msg != messages[MessageAll].end(); ++msg)
+    std::deque<ControlPanelMessage>::const_iterator msg = messages[messageMode].begin()++;
+    for (; msg != messages[messageMode].end(); ++msg)
     {
         const std::string line = msg->getString(timestamp);
         if (stripAnsi)


### PR DESCRIPTION
Adjust command /savemsg to save console messages based on what tab you're focused on. If you have it on "All" (the default) it works the same. Chat, Server, and Misc tabs would sort accordingly and save only what is shown in the console at the time.