### PR TITLE
Fix joystick scaling

### DIFF
--- a/src/bzflag/HUDuiJSTestLabel.cxx
+++ b/src/bzflag/HUDuiJSTestLabel.cxx
@@ -67,13 +67,13 @@ void            HUDuiJSTestLabel::doRender()
     glVertex2f(getX() + (1.0f + rangeLimit) / 2.0f * width, getY() + (1.0f + rangeLimit) / 2.0f * height);
     glEnd();
 
-    //draw a box around the test area
+    // draw a box around the full -1, 1 range
     glColor4fv(boxColor);
     glBegin(GL_LINE_LOOP);
-    glVertex2f(getX() + (1.0f - 1) / 2.0f * width, getY() + (1.0f + 1) / 2.0f * height);
-    glVertex2f(getX() + (1.0f - 1) / 2.0f * width, getY() + (1.0f - 1) / 2.0f * height);
-    glVertex2f(getX() + (1.0f + 1) / 2.0f * width, getY() + (1.0f - 1) / 2.0f * height);
-    glVertex2f(getX() + (1.0f + 1) / 2.0f * width, getY() + (1.0f + 1) / 2.0f * height);
+    glVertex2f(getX(), getY() + height);
+    glVertex2f(getX(), getY());
+    glVertex2f(getX() + width, getY());
+    glVertex2f(getX() + width, getY() + height);
     glEnd();
 
     // draw the real cursor
@@ -97,8 +97,8 @@ void            HUDuiJSTestLabel::doRender()
     // draw the modified cursor
     mainWindow->getJoyPosition(jsx, jsy);
     applyJSModifiers(jsx, jsy);
-    jsxTransformed = ((1.0f + jsx) / 2.0f) * width;
-    jsyTransformed = ((1.0f - jsy) / 2.0f) * height;
+    jsxTransformed = (1.0f + jsx * rangeLimit) / 2.0f * width;
+    jsyTransformed = (1.0f - jsy * rangeLimit) / 2.0f * height;
     glColor4fv(modifiedCursorColor);
     glBegin(GL_TRIANGLE_FAN);
     glVertex2f(getX() + jsxTransformed, getY() + jsyTransformed - modifiedCursorLength / 2.0f);

--- a/src/bzflag/HUDuiJSTestLabel.cxx
+++ b/src/bzflag/HUDuiJSTestLabel.cxx
@@ -48,6 +48,7 @@ void            HUDuiJSTestLabel::doRender()
 
     // appearance constants
     const float backgroundColor[] = { 0.0f, 0.0f, 0.0f, 0.75f };
+    const float boxColor[] = { 0.25f, 0.25f, 0.25f, 0.75f };
 
     const auto realCursorThickness = BZ_SCALE_JS_TEST_ELEMS(2);
     const auto realCursorLength = BZ_SCALE_JS_TEST_ELEMS(40.0f);
@@ -64,6 +65,15 @@ void            HUDuiJSTestLabel::doRender()
     glVertex2f(getX() + (1.0f - rangeLimit) / 2.0f * width, getY() + (1.0f - rangeLimit) / 2.0f * height);
     glVertex2f(getX() + (1.0f + rangeLimit) / 2.0f * width, getY() + (1.0f - rangeLimit) / 2.0f * height);
     glVertex2f(getX() + (1.0f + rangeLimit) / 2.0f * width, getY() + (1.0f + rangeLimit) / 2.0f * height);
+    glEnd();
+
+    //draw a box around the test area
+    glColor4fv(boxColor);
+    glBegin(GL_LINE_LOOP);
+    glVertex2f(getX() + (1.0f - 1) / 2.0f * width, getY() + (1.0f + 1) / 2.0f * height);
+    glVertex2f(getX() + (1.0f - 1) / 2.0f * width, getY() + (1.0f - 1) / 2.0f * height);
+    glVertex2f(getX() + (1.0f + 1) / 2.0f * width, getY() + (1.0f - 1) / 2.0f * height);
+    glVertex2f(getX() + (1.0f + 1) / 2.0f * width, getY() + (1.0f + 1) / 2.0f * height);
     glEnd();
 
     // draw the real cursor

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -910,7 +910,7 @@ void     applyJSModifiers(float& jsx, float& jsy)
     const auto jsRangeMax = std::max(std::min(float(BZDB.evalInt("jsRangeMax")) / 100.0f, 1.0f), 0.25f);
     const auto jsRangeMin = std::max(std::min(float(BZDB.evalInt("jsRangeMin")) / 100.0f, 0.2f), 0.0f);
 
-    // joystick axes inversion values
+    // invert axes
     // 0: no inversion
     // 1: invert X
     // 2: invert Y
@@ -918,28 +918,8 @@ void     applyJSModifiers(float& jsx, float& jsy)
     jsx *= BZDB.evalInt("jsInvertAxes") % 2 == 1 ? -1.0f : 1.0f;
     jsy *= BZDB.evalInt("jsInvertAxes") > 1 ? -1.0f : 1.0f;
 
-    // scaled radial dead zone and cap
-    const auto jsMagnitude = std::sqrt(jsx * jsx + jsy * jsy);
-    const auto jsRangeMultiplier = (jsMagnitude - jsRangeMin) / (jsRangeMax - jsRangeMin) / jsMagnitude;
-
-    // exponential ramp
-    const auto jsRampType = BZDB.get("jsRampType");
-    auto jsRampFactor = jsRangeMultiplier;
-    if(jsRampType == "squared")
-        jsRampFactor = std::pow(jsRangeMultiplier, 2.0f);
-    else if(jsRampType == "cubed")
-        jsRampFactor = std::pow(jsRangeMultiplier, 3.0f);
-
-    // apply both factors
-    if(jsMagnitude < jsRangeMin || isnan(jsRangeMultiplier))
-        jsx = jsy = 0.0f;
-    else
-    {
-        jsx *= jsRampFactor;
-        jsy *= jsRampFactor;
-    }
-
     // stretch corners
+    const auto jsMagnitude = std::sqrt(jsx * jsx + jsy * jsy);
     if(BZDB.isTrue("jsStretchCorners"))
     {
         const auto stretchFactor = (1.0f - float(std::abs(std::abs(atan(jsy / jsx) / M_PI) - 0.25f)) * 4.0f) * jsMagnitude;
@@ -952,12 +932,39 @@ void     applyJSModifiers(float& jsx, float& jsy)
         }
     }
 
-    // proportionally scale the coordinates back to the range limit
+    // apply scaled radial dead zone and range limit
+    const auto jsRadialDeadZoneScale = (jsMagnitude - jsRangeMin) / (jsRangeMax - jsRangeMin) / jsMagnitude;
+    if(jsMagnitude < jsRangeMin || isnan(jsRadialDeadZoneScale))
+        jsx = jsy = 0.0f;
+    else if(jsMagnitude < jsRangeMax) // apply scale between edge of dead zone and range limit radius
+    {
+        jsx *= jsRadialDeadZoneScale;
+        jsy *= jsRadialDeadZoneScale;
+    }
+    else
+    {
+        jsx /= jsRangeMax;
+        jsy /= jsRangeMax;
+    }
+
+    // apply exponential ramp
+    const auto jsRampType = BZDB.get("jsRampType");
+    auto jsRampMultiplier = 1.0f;
+
+    if(jsRampType == "squared")
+        jsRampMultiplier = jsMagnitude / jsRangeMax;
+    else if(jsRampType == "cubed")
+        jsRampMultiplier = std::pow(jsMagnitude / jsRangeMax, 2.0f);
+
+    jsx *= jsRampMultiplier;
+    jsy *= jsRampMultiplier;
+
+    // proportionally scale the coordinates back to the -1, 1 range box
     const auto jsxAbs = std::abs(jsx);
     const auto jsyAbs = std::abs(jsy);
     if(jsxAbs > 1 || jsyAbs > 1)
     {
-        const auto jsRangeExcess = (jsxAbs > jsyAbs ? jsxAbs : jsyAbs) / 1;
+        const auto jsRangeExcess = (jsxAbs > jsyAbs ? jsxAbs : jsyAbs);
         jsx /= jsRangeExcess;
         jsy /= jsRangeExcess;
     }
@@ -1532,7 +1539,7 @@ static Player*      addPlayer(PlayerId id, const void* msg, int showMessage)
         printError (TextUtils::format ("Invalid player identification (%d)", i));
         std::
         cerr <<
-             "WARNING: invalid player identification when adding player with id "
+        "WARNING: invalid player identification when adding player with id "
              << i << std::endl;
         return NULL;
     }
@@ -5477,7 +5484,7 @@ static void joinInternetGame()
 
     // open server
     ServerLink* _serverLink = new ServerLink(serverNetworkAddress,
-            startupInfo.serverPort);
+        startupInfo.serverPort);
 
 #if defined(ROBOT)
     numRobots = 0;

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -920,7 +920,7 @@ void     applyJSModifiers(float& jsx, float& jsy)
 
     // scaled radial dead zone and cap
     const auto jsMagnitude = std::sqrt(jsx * jsx + jsy * jsy);
-    const auto jsRangeMultiplier = jsRangeMax * (jsMagnitude - jsRangeMin) / (jsRangeMax - jsRangeMin) / jsMagnitude;
+    const auto jsRangeMultiplier = (jsMagnitude - jsRangeMin) / (jsRangeMax - jsRangeMin) / jsMagnitude;
 
     // exponential ramp
     const auto jsRampType = BZDB.get("jsRampType");
@@ -955,9 +955,9 @@ void     applyJSModifiers(float& jsx, float& jsy)
     // proportionally scale the coordinates back to the range limit
     const auto jsxAbs = std::abs(jsx);
     const auto jsyAbs = std::abs(jsy);
-    if(jsxAbs > jsRangeMax || jsyAbs > jsRangeMax)
+    if(jsxAbs > 1 || jsyAbs > 1)
     {
-        const auto jsRangeExcess = (jsxAbs > jsyAbs ? jsxAbs : jsyAbs) / jsRangeMax;
+        const auto jsRangeExcess = (jsxAbs > jsyAbs ? jsxAbs : jsyAbs) / 1;
         jsx /= jsRangeExcess;
         jsy /= jsRangeExcess;
     }

--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -1539,7 +1539,7 @@ static Player*      addPlayer(PlayerId id, const void* msg, int showMessage)
         printError (TextUtils::format ("Invalid player identification (%d)", i));
         std::
         cerr <<
-        "WARNING: invalid player identification when adding player with id "
+             "WARNING: invalid player identification when adding player with id "
              << i << std::endl;
         return NULL;
     }
@@ -5484,7 +5484,7 @@ static void joinInternetGame()
 
     // open server
     ServerLink* _serverLink = new ServerLink(serverNetworkAddress,
-        startupInfo.serverPort);
+            startupInfo.serverPort);
 
 #if defined(ROBOT)
     numRobots = 0;


### PR DESCRIPTION
Adjust the joystick scaling to properly have full range of speed between jsRangeMin and jsRangeMax.
The way it worked before, the speed of the tank would be limited to the percentage of jsRangeMax.
I also added a box to the joystick testing menu so you can clearly see where the outer limits are.
![image](https://github.com/user-attachments/assets/9b2d5dbd-3449-4dbd-82e1-2d5e3ac2e1bd)
