### PR TITLE
WIN32: Fix build of bzflag.rc on MinGW/CYGWIN

### DIFF
--- a/src/bzflag/Makefile.am
+++ b/src/bzflag/Makefile.am
@@ -222,6 +222,6 @@ LDADD =	\
 # This is required to hook in ogg/vorbis libraries
 #	$(ALIBS)
 
-bzflag.res: $(top_srcdir)/win32/bzflag.rc $(top_srcdir)/win32/bzflag.ico
-	$(WINDRES) --include-dir=$(top_srcdir)/win32/ -i $(top_srcdir)/win32/bzflag.rc -o bzflag.res \
+bzflag.res: $(top_srcdir)/MSVC/bzflag.rc $(top_srcdir)/MSVC/bzflag.ico
+	$(WINDRES) --include-dir=$(top_srcdir)/MSVC/ -i $< -o $@ \
 	-O coff


### PR DESCRIPTION
Compiling on MinGW/CYGWIN prints an error because `bzflag.rc` is not found.
This is correct because `bzflag.rc` is not under `/win32` (that doesn't exist) but it's under `/MSVC`.
This patch fixes this error.