### PR TITLE
Optimize RadarRenderer::renderBoxPyrMesh()

### DIFF
--- a/include/MeshObstacle.h
+++ b/include/MeshObstacle.h
@@ -122,6 +122,22 @@ public:
     void print(std::ostream& out, const std::string& indent) const override;
     void printOBJ(std::ostream& out, const std::string& indent) const override;
 
+    /**
+      * @brief Cache structure for pre-computed 2D radar geometry and visibility.
+      */
+    struct RadarFaceCache
+    {
+        float vx[4];         // Pre-transformed 2D X coordinates for up to 4 vertices (16 bytes)
+        float vy[4];         // Pre-transformed 2D Y coordinates for up to 4 vertices (16 bytes)
+
+        float posZ;          // Cached Z-axis position (4 bytes)
+        float sizeZ;         // Cached Z-axis height extent (4 bytes)
+        uint8_t vertexCount; // Number of vertices (capped at 4 for fast path, 255 = fetch from mesh) (1 byte)
+        bool  noRadar;       // True if face should be skipped during enhanced radar rendering (1 byte)
+        int   isDeath;       // True if face represents a death/hazard zone tint (1 byte)
+    };
+    std::vector<RadarFaceCache> radarCache;
+
 private:
     void makeFacePointers(const std::vector<int>& _vertices,
                           const std::vector<int>& _normals,

--- a/src/bzflag/RadarRenderer.cxx
+++ b/src/bzflag/RadarRenderer.cxx
@@ -1065,42 +1065,75 @@ void RadarRenderer::renderBoxPyrMesh()
     for (i = 0; i < count; i++)
     {
         const MeshObstacle* mesh = (const MeshObstacle*) meshes[i];
+        const auto* cachePtr = mesh->radarCache.data();
         int faces = mesh->getFaceCount();
+
+        // Check if mesh-level Z and height should override face values.
+        // If true, compute z, bh, colorScale, and transScale ONCE per mesh instead of per face.
+        const bool useMeshZ = BZDBCache::useMeshForRadar;
+        float cs = 0.0f, ts = 0.0f;
+
+        if (useMeshZ)
+        {
+            const float z  = mesh->getPosition()[2];
+            const float bh = mesh->getSize()[2];
+            cs = colorScale(z, bh);
+            ts = transScale(z, bh);
+        }
 
         for (int f = 0; f < faces; f++)
         {
-            const MeshFace* face = mesh->getFace(f);
-            if (enhanced)
-            {
-                if (face->getPlane()[2] <= 0.0f)
-                    continue;
-                const BzMaterial* bzmat = face->getMaterial();
-                if ((bzmat != NULL) && bzmat->getNoRadar())
-                    continue;
-            }
-            float z = face->getPosition()[2];
-            float bh = face->getSize()[2];
+            // Access pre-computed face properties from contiguous memory
+            const auto& cache = cachePtr[f];
 
-            if (BZDBCache::useMeshForRadar)
+            // In enhanced radar mode, skip rendering faces marked as non-visible to radar
+            if (enhanced && cache.noRadar)
+                continue;
+
+            if (!useMeshZ)
             {
-                z = mesh->getPosition()[2];
-                bh = mesh->getSize()[2];
+                // Retrieve cached Z-position and building height bounds
+                const float z  = cache.posZ;
+                const float bh = cache.sizeZ;
+                // Compute per-face color and transparency
+                cs = colorScale(z, bh);
+                ts = transScale(z, bh);
             }
 
-            const float cs = colorScale(z, bh);
-            // draw death faces with a soupcon of red
-            const PhysicsDriver* phydrv = PHYDRVMGR.getDriver(face->getPhysicsDriver());
-            if ((phydrv != NULL) && phydrv->getIsDeath())
-                glColor4f(0.75f * cs, 0.25f * cs, 0.25f * cs, transScale(z, bh));
+            // Apply distinct radar color tinting (death zones get a reddish tint)
+            if (cache.isDeath)
+                glColor4f(0.75f * cs, 0.25f * cs, 0.25f * cs, ts);
             else
-                glColor4f(0.25f * cs, 0.5f * cs, 0.5f * cs, transScale(z, bh));
-            // draw the face as a triangle fan
-            int vertexCount = face->getVertexCount();
+                glColor4f(0.25f * cs, 0.5f * cs, 0.5f * cs, ts);
+
+            int vertexCount = cache.vertexCount;
+            const MeshFace* face = nullptr;
+
+            // Lazy pointer lookup: only query the original MeshFace if the polygon has more than 4 vertices
+            if (vertexCount > 4)
+                face = mesh->getFace(f);
+
+            // Sentinel check: a stored count of 255 indicates the face exceeds byte capacity,
+            // so we fetch the true total vertex count dynamically from the MeshFace object
+            if (vertexCount == 255)
+                vertexCount = face->getVertexCount();
+
+            // Render the radar outline/fill using a 2D triangle fan
             glBegin(GL_TRIANGLE_FAN);
-            for (int v = 0; v < vertexCount; v++)
+
+            // FAST PATH: Stream up to 4 pre-cached 2D coordinates directly from L1/L2 CPU cache
+            const int inlinedCount = std::min(vertexCount, 4);
+            for (int v = 0; v < inlinedCount; v++)
+                glVertex2f(cache.vx[v], cache.vy[v]);
+
+            // FALLBACK PATH: For complex n-gons (> 4 vertices), fetch the remaining 2D coordinates from MeshFace
+            if (vertexCount > 4)
             {
-                const float* pos = face->getVertex(v);
-                glVertex2f(pos[0], pos[1]);
+                for (int v = 4; v < vertexCount; v++)
+                {
+                    const float* pos = face->getVertex(v);
+                    glVertex2f(pos[0], pos[1]);
+                }
             }
             glEnd();
         }

--- a/src/obstacle/MeshObstacle.cxx
+++ b/src/obstacle/MeshObstacle.cxx
@@ -28,6 +28,7 @@
 #include "MeshDrawInfo.h"
 #include "MeshTransform.h"
 #include "StateDatabase.h"
+#include "PhysicsDriver.h"
 
 // local headers
 #include "Triangulate.h"
@@ -392,10 +393,52 @@ void MeshObstacle::finalize()
     for (f = 0; f < faceCount; f++)
         faces[f]->edges = NULL;
 
-    // set the extents
+    // Reset cache container while retaining allocated capacity to avoid dynamic memory reallocation
+    radarCache.clear();
+    radarCache.reserve(faceCount);
+
+    // Populate pre-computed 2D vertex positions, height extents, and material flags for each face
     for (f = 0; f < faceCount; f++)
     {
-        const Extents& exts = faces[f]->getExtents();
+        const auto& face = *faces[f];
+        const Extents& exts = face.getExtents();
+
+        RadarFaceCache cache;
+
+        // Skip rendering on radar if the face points downward/flat (plane normal Z <= 0)
+        // or if explicitly marked invisible to radar via its material property
+        if (face.getPlane()[2] <= 0.0f)
+            cache.noRadar = true;
+        else
+        {
+            const BzMaterial* bzmat = face.getMaterial();
+            cache.noRadar = (bzmat && bzmat->getNoRadar());
+        }
+
+        // Cache 3D height parameters (center Z and Z extent) for elevation checks
+        cache.posZ        = face.getPosition()[2];
+        cache.sizeZ       = face.getSize()[2];
+
+        // Query physical driver to determine if this face acts as a hazard/death zone
+        const int phydrvId          = face.getPhysicsDriver();
+        const PhysicsDriver* phydrv = PHYDRVMGR.getDriver(phydrvId);
+        cache.isDeath               = phydrv ? phydrv->getIsDeath() : false;
+
+        // Clamp total face count to uint8 range (255 max)
+        cache.vertexCount = std::min(face.getVertexCount(), 255);
+
+        // Store up to 4 vertex positions in contiguous local array for fast-path rendering
+        for (int v = 0; v < std::min(cache.vertexCount, uint8_t(4)); ++v)
+        {
+            const float* vpos = face.getVertex(v);
+            cache.vx[v] = vpos[0];
+            cache.vy[v] = vpos[1];
+        }
+
+        // Append to cache vector (contiguous memory write)
+        radarCache.push_back(cache);
+
+        // Expand total bounding box volume to encompass current face extents
         extents.expandToBox(exts);
     }
 


### PR DESCRIPTION
This reduce the time spent on the RadarRenderer::renderBoxPyrMesh()

Here before the cure it was at 17 % now is about 6%. The FPS has not moved much,maybe openGL is blocking it.
Got some performance report with perf record src/bzflag/bzflag and perf report:

This is before the change on an empty "Apocalipse Neutral"
  14.31%  bzflag         bzflag                   [.] RadarRenderer::renderBoxPyrMesh()
   2.82%  bzflag         libc.so.6                [.] __memcmp_evex_movbe
   0.56%  bzflag         libc.so.6                [.] __memmove_evex_unaligned_erms
   0.54%  bzflag         libgallium-26.0.8.so     [.] 0x00000000002fb2ac
   0.53%  bzflag         libgallium-26.0.8.so     [.] 0x0000000000267530
   0.49%  bzflag:gdrv0   libgallium-26.0.8.so     [.] 0x0000000000d3e936
   0.49%  bzflag         bzflag                   [.] OpenGLGStateState::setOpenGLState(OpenGLGStateState const*) const
   0.47%  bzflag         bzflag                   [.] SortedGState::add(OpenGLGStateRep*)
   0.46%  bzflag         libgallium-26.0.8.so     [.] 0x00000000002fb2d0
   0.44%  bzflag         bzflag                   [.] TextureManager::bind(int)
   0.43%  bzflag         bzflag                   [.] StateDatabase::eval(std::__cxx11::basic_string<char, std::char_traits<cha
   0.40%  bzflag         libgallium-26.0.8.so     [.] 0x0000000000301002
   0.39%  bzflag         bzflag                   [.] testAxisBoxInFrustum(Extents const&, Frustum const*)
   0.39%  bzflag         bzflag                   [.] OctreeNode::getFrustumList() const
   0.38%  bzflag         bzflag                   [.] OpenGLGStateBuilder::OpenGLGStateBuilder(OpenGLGState const&)
   0.35%  bzflag         libgallium-26.0.8.so     [.] 0x000000000008aa31

This is after
   6.29%  bzflag         bzflag                   [.] RadarRenderer::renderBoxPyrMesh()
   3.01%  bzflag         libc.so.6                [.] __memcmp_evex_movbe
   0.59%  bzflag         libgallium-26.0.8.so     [.] 0x00000000002fb2ac
   0.58%  bzflag         bzflag                   [.] OpenGLGStateState::setOpenGLState(OpenGLGStateState const*) const
   0.57%  bzflag         libgallium-26.0.8.so     [.] 0x00000000002fb2d0
   0.57%  bzflag         libc.so.6                [.] __memmove_evex_unaligned_erms
   0.56%  bzflag         bzflag                   [.] SortedGState::add(OpenGLGStateRep*)
   0.54%  bzflag         libgallium-26.0.8.so     [.] 0x0000000000267530
   0.52%  bzflag:gdrv0   libgallium-26.0.8.so     [.] 0x0000000000d3e936
   0.50%  bzflag         bzflag                   [.] TextureManager::bind(int)
   0.46%  bzflag         bzflag                   [.] OctreeNode::getFrustumList() const
   0.44%  bzflag         libgallium-26.0.8.so     [.] 0x0000000000301002
   0.43%  bzflag         bzflag                   [.] StateDatabase::eval(std::__cxx11::basic_string<char, std::char_traits<cha
   0.39%  bzflag         libgallium-26.0.8.so     [.] 0x0000000000a13af7
   0.39%  bzflag         libgallium-26.0.8.so     [.] 0x0000000000267528
   0.38%  bzflag         bzflag                   [.] testAxisBoxInFrustum(Extents const&, Frustum const*)


Without VBO we cannot do better IMHO