### PR TITLE
Recalculate team scores in FFA when a player leaves

### DIFF
--- a/src/bzfs/bzfs.cxx
+++ b/src/bzfs/bzfs.cxx
@@ -2961,6 +2961,15 @@ void removePlayer(int playerIndex, const char *reason, bool notify)
         int teamNum = int(playerData->player.getTeam());
         --team[teamNum].team.size;
 
+        // change team wins/losses
+        if(clOptions->gameType == TeamFFA && Team::isColorTeam(playerData->player.getTeam()))
+        {
+            int newTeamWins = team[teamNum].team.getWins() - playerData->score.getWins();
+            int newTeamLosses = team[teamNum].team.getLosses() - playerData->score.getLosses();
+            team[teamNum].team.setWins(newTeamWins);
+            team[teamNum].team.setLosses(newTeamLosses);
+        }
+
         // if last active player on team then remove team's flag if no one
         // is carrying it
         if (Team::isColorTeam((TeamColor)teamNum)


### PR DESCRIPTION
On maps like Badgerking where there are a lot of deaths, you can sometimes end up with a team score of -50 while the only player on that team has a score of -2. This pull request fixes that by recalculating team scores whenever a player leaves.