### PR TITLE
fix downcast

### DIFF
--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -3511,11 +3511,20 @@ static void     handlePlayerMessage(uint16_t code, uint16_t,
     {
         ShotUpdate shot;
         msg = shot.unpack(msg);
-        Player* tank = lookupPlayer(shot.player);
+        PlayerId playerId = shot.player;
+        Player* tank = lookupPlayer(playerId);
         if (!tank || tank == myTank) break;
-        RemotePlayer* remoteTank = (RemotePlayer*)tank;
-        RemoteShotPath* shotPath =
-            (RemoteShotPath*)remoteTank->getShot(shot.id);
+        RemoteShotPath* shotPath;
+        if (playerId == ServerPlayer)
+        {
+            WorldPlayer* remotePlayer = static_cast<WorldPlayer*>(tank);
+            shotPath = (RemoteShotPath*)remotePlayer->getShot(shot.id);
+        }
+        else
+        {
+            RemotePlayer* remoteTank = (RemotePlayer*)tank;
+            shotPath = (RemoteShotPath*)remoteTank->getShot(shot.id);
+        }
         if (shotPath) shotPath->update(shot, code, msg);
         PlayerId targetId;
         msg = nboUnpackUByte(msg, targetId);


### PR DESCRIPTION
When receiving a GM_UPDATE the current code does not check if it is coming from a RemotePlayer or a WorldPlayer.
This try to fix it.
A more elegant solution should be to generate an ancestor of the 2 classes, but is more intrusive