### PR TITLE
Fix duplicate "Team" shown to user when auto-assigning teams

### DIFF
--- a/src/bzflag/playing.cxx
+++ b/src/bzflag/playing.cxx
@@ -5022,7 +5022,7 @@ static void enteringServer(const void *buf)
     std::string teamMsg;
     if (myTank->getTeam() != AutomaticTeam)
     {
-        teamMsg = TextUtils::format("%s team was unavailable, you were joined ",
+        teamMsg = TextUtils::format("%s was unavailable, you were joined ",
                                     Team::getName(myTank->getTeam()));
         if ((TeamColor)team == ObserverTeam)
             teamMsg += "as an Observer";


### PR DESCRIPTION
Before:
<img width="666" height="21" alt="Screenshot 2026-07-14 at 2 44 39 PM" src="https://github.com/user-attachments/assets/f4a8f1a9-0539-4edd-8c1e-6934f290271d" />

After:
<img width="605" height="20" alt="Screenshot 2026-07-14 at 2 44 08 PM" src="https://github.com/user-attachments/assets/9553828e-8909-4ce6-ba83-8215d1dbc636" />
