### PR TITLE
Extend .gitignore with JetBrains files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ Thumbs.db
 /tools/TextTool2/TextTool2.xcodeproj/project.xcworkspace
 /MSVC/HoldTheFlag_Win32_Debug/*.ib_pdb_index
 *.ib_pdb_index
+

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ dependencies/
 .vs
 *.aps
 
+# JetBrains files
+.idea
+*.iml
+
 # GNU Autotools
 Makefile.in
 Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ dependencies/
 *.idb
 *.pdb
 *.suo
-*.lib
 *.user
 *.log
 *.cache
@@ -140,4 +139,3 @@ Thumbs.db
 /tools/TextTool2/TextTool2.xcodeproj/project.xcworkspace
 /MSVC/HoldTheFlag_Win32_Debug/*.ib_pdb_index
 *.ib_pdb_index
-


### PR DESCRIPTION
JetBrains files are currently not being ignored. This PR adds a JetBrains files section below the Visual Studio files section. It also removes the redundant second `*.lib` match.