### PR TITLE
Simplify updating the version number

### DIFF
--- a/DEVINFO
+++ b/DEVINFO
@@ -455,7 +455,8 @@ cannot proceed.  A checklist of items to be completed follows:
   increment it one more time in buildDate.cxx, bzfquery.*, and
   bzls.lua to distinguish the new release from development versions.
 
-- BZ_BUILD_TYPE is changed to STABLE in buildDate.cxx.
+- BZ_BUILD_TYPE is changed to STABLE and BZ_BUILD_TYPE_REVISION is
+  changed to 0 in buildDate.cxx.
 
 - Perform a "make distcheck" on multiple (preferably all) platforms.
   This will verify that a proper source distribution can be made.

--- a/DEVINFO
+++ b/DEVINFO
@@ -444,10 +444,8 @@ cannot proceed.  A checklist of items to be completed follows:
 - Man files and bzfs.conf files are updated with latest changes.
 
 - Version numbers are updated to the next expected release number.
-  This minimally includes updating README, ChangeLog, configure.ac,
-  version_defs.h, Xcode/BZFlag.xcodeproj/project.pbxproj,
-  Xcode/BZFlag-Info.plist, and the title.png image.  Version numbers in all
-  other platform-specific README.* files should also be verified.
+  This minimally includes updating README, ChangeLog, version_defs.h,
+  and title.png, and misc/updateversion.py has been run.
 
 - Edit updateConfigFile in clientConfig.cxx to update any necessary
   configuration settings, and remove the 'break;' from the latest switch

--- a/DEVINFO
+++ b/DEVINFO
@@ -444,8 +444,8 @@ cannot proceed.  A checklist of items to be completed follows:
 - Man files and bzfs.conf files are updated with latest changes.
 
 - Version numbers are updated to the next expected release number.
-  This minimally includes updating README, ChangeLog, version_defs.h,
-  and title.png, and misc/updateversion.py has been run.
+  This minimally includes updating ChangeLog, version_defs.h, and
+  title.png, and misc/updateversion.py has been run.
 
 - Edit updateConfigFile in clientConfig.cxx to update any necessary
   configuration settings, and remove the 'break;' from the latest switch

--- a/DEVINFO
+++ b/DEVINFO
@@ -376,11 +376,11 @@ global.
 
 Version numbers
 ===============
-The BZFlag versioning info is defined in:   include/version.h
+The BZFlag versioning info is defined in: include/version_defs.h
 
 There are a number of #defines in that file that define the Major,
-Minor, and Revision versions, as well as the build type, build date,
-build user, and network protocol version.
+Minor, and Revision versions, as well as the build type, build type
+revision, and network protocol version.
 
 The BZFlag version number is in the format of:
 
@@ -418,10 +418,10 @@ __DATE__ macro.
 
 BuildType is a string that represents the intended use of the build.
 For development releases, the build type is normally "DEVEL".  For
-testing releases, the build type can be "ALPHA", "BETA", "RC1" etc.
-For final release versions the build type should be "STABLE" or
-"MAINT".  The build type provides a human readable keyword for the
-version and intended or expected stability of the build.
+testing releases, the build type can be "ALPHA", "BETA", or "RC".
+For final release versions the build type should be "STABLE".  The
+build type provides a human readable keyword for the version and
+intended or expected stability of the build.
 
 BuildOS is the operating system that the building system is running;
 on systems that use the automake build system this is automatically
@@ -445,7 +445,7 @@ cannot proceed.  A checklist of items to be completed follows:
 
 - Version numbers are updated to the next expected release number.
   This minimally includes updating README, ChangeLog, configure.ac,
-  buildDate.cxx, Version.rc, Xcode/BZFlag.xcodeproj/project.pbxproj,
+  version_defs.h, Xcode/BZFlag.xcodeproj/project.pbxproj,
   Xcode/BZFlag-Info.plist, and the title.png image.  Version numbers in all
   other platform-specific README.* files should also be verified.
 
@@ -457,10 +457,7 @@ cannot proceed.  A checklist of items to be completed follows:
   increment it one more time in buildDate.cxx, bzfquery.*, and
   bzls.lua to distinguish the new release from development versions.
 
-- BZ_BUILD_TYPE is changed to MAINT in buildDate.cxx.
-
-- Update package/win32/nsis/*.nsi (for windows) with appropriate
-  version numbers.
+- BZ_BUILD_TYPE is changed to STABLE in buildDate.cxx.
 
 - Perform a "make distcheck" on multiple (preferably all) platforms.
   This will verify that a proper source distribution can be made.

--- a/DEVINFO
+++ b/DEVINFO
@@ -427,9 +427,6 @@ BuildOS is the operating system that the building system is running;
 on systems that use the automake build system this is automatically
 generated.
 
-If a build includes SDL or SDL2, the build string ends in "-SDL" or
-"-SDL2", respectively.
-
 Making a Release
 ================
 In order to make a release, there are handful of steps that need to be

--- a/MSVC/Version.rc
+++ b/MSVC/Version.rc
@@ -1,6 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"
+#include "version_defs.h"
 /////////////////////////////////////////////////////////////////////////////
 // English (United States) resources
 
@@ -14,8 +15,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,4,31,0
- PRODUCTVERSION 2,4,31,0
+ FILEVERSION BZ_MAJOR_VERSION, BZ_MINOR_VERSION, BZ_REV, 0
+ PRODUCTVERSION BZ_MAJOR_VERSION, BZ_MINOR_VERSION, BZ_REV, 0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -32,12 +33,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Tim Riker"
             VALUE "FileDescription", "BZFlag"
-            VALUE "FileVersion", "2.4.31.0"
+            VALUE "FileVersion", BZ_VERSION_STR
             VALUE "InternalName", "version.rc"
             VALUE "LegalCopyright", "Copyright (c) 1993-2025 Tim Riker"
             VALUE "OriginalFilename", "version.rc"
             VALUE "ProductName", "BZFlag"
-            VALUE "ProductVersion", "2.4.31.0"
+            VALUE "ProductVersion", BZ_VERSION_STR
         END
     END
     BLOCK "VarFileInfo"

--- a/MSVC/build/bzadmin.vcxproj
+++ b/MSVC/build/bzadmin.vcxproj
@@ -110,6 +110,7 @@
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>pdcurses.lib;regex.lib;libcurl_debug.lib;ws2_32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -161,6 +162,7 @@ copy "..\..\dependencies\windows-$(Configuration)-$(PlatformShortName)\bin\*.dll
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>pdcurses.lib;regex.lib;libcurl_debug.lib;ws2_32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -210,6 +212,7 @@ copy "..\..\dependencies\windows-$(Configuration)-$(PlatformShortName)\bin\*.dll
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>pdcurses.lib;regex.lib;libcurl.lib;ws2_32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -260,6 +263,7 @@ copy "..\..\dependencies\windows-$(Configuration)-$(PlatformShortName)\bin\*.dll
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>pdcurses.lib;regex.lib;libcurl.lib;ws2_32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/MSVC/build/bzflag.vcxproj
+++ b/MSVC/build/bzflag.vcxproj
@@ -127,6 +127,7 @@
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>caresd.lib;libcurl_debug.lib;regex.lib;glew32sd.lib;SDL2.lib;SDL2main.lib;zlib.lib;ws2_32.lib;dsound.lib;winmm.lib;glu32.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -189,6 +190,7 @@ copy "..\..\dependencies\licenses\*" "..\..\bin_$(Configuration)_$(Platform)\lic
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>caresd.lib;libcurl_debug.lib;regex.lib;glew32sd.lib;SDL2.lib;SDL2main.lib;zlib.lib;ws2_32.lib;dsound.lib;winmm.lib;glu32.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -249,6 +251,7 @@ copy "..\..\dependencies\licenses\*" "..\..\bin_$(Configuration)_$(Platform)\lic
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>cares.lib;libcurl.lib;regex.lib;glew32s.lib;SDL2.lib;SDL2main.lib;zlib.lib;ws2_32.lib;dsound.lib;winmm.lib;glu32.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -306,6 +309,7 @@ copy "..\..\dependencies\licenses\*" "..\..\bin_$(Configuration)_$(Platform)\lic
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>cares.lib;libcurl.lib;regex.lib;glew32s.lib;SDL2.lib;SDL2main.lib;zlib.lib;ws2_32.lib;dsound.lib;winmm.lib;glu32.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -914,6 +918,7 @@ copy "..\..\dependencies\licenses\*" "..\..\bin_$(Configuration)_$(Platform)\lic
     <ResourceCompile Include="..\Version.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\include\version_defs.h" />
     <ClInclude Include="..\..\src\bzflag\defaultBZDB.h" />
     <ClInclude Include="..\..\src\bzflag\clientConfig.h" />
     <ClInclude Include="..\..\src\bzflag\BackgroundRenderer.h" />

--- a/MSVC/build/bzflag.vcxproj.filters
+++ b/MSVC/build/bzflag.vcxproj.filters
@@ -543,6 +543,9 @@
     <ClInclude Include="..\..\src\bzflag\JoystickTestMenu.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\version_defs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\bzflag.ico">

--- a/MSVC/build/bzfs.vcxproj
+++ b/MSVC/build/bzfs.vcxproj
@@ -108,6 +108,7 @@
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>cares.lib;libcurl.lib;regex.lib;zlib.lib;ws2_32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -158,6 +159,7 @@ copy "..\..\dependencies\windows-$(Configuration)-$(PlatformShortName)\bin\*.dll
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>cares.lib;libcurl.lib;regex.lib;zlib.lib;ws2_32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -209,6 +211,7 @@ copy "..\..\dependencies\windows-$(Configuration)-$(PlatformShortName)\bin\*.dll
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>caresd.lib;libcurl_debug.lib;regex.lib;zlib.lib;ws2_32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -261,6 +264,7 @@ copy "..\..\dependencies\windows-$(Configuration)-$(PlatformShortName)\bin\*.dll
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>caresd.lib;libcurl_debug.lib;regex.lib;zlib.lib;ws2_32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/MSVC/build/common.vcxproj
+++ b/MSVC/build/common.vcxproj
@@ -528,6 +528,7 @@
     <ClInclude Include="..\..\include\CommandManager.h" />
     <ClInclude Include="..\..\include\common.h" />
     <ClInclude Include="..\..\include\mathRoutine.h" />
+    <ClInclude Include="..\..\include\version_defs.h" />
     <ClInclude Include="config.h" />
     <ClInclude Include="..\..\include\ConfigFileManager.h" />
     <ClInclude Include="..\..\include\Country.h" />

--- a/MSVC/build/common.vcxproj.filters
+++ b/MSVC/build/common.vcxproj.filters
@@ -243,6 +243,9 @@
     <ClInclude Include="..\..\include\mathRoutine.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\version_defs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files">

--- a/MSVC/build/date.vcxproj
+++ b/MSVC/build/date.vcxproj
@@ -231,6 +231,7 @@ del __bd.cxx
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\version.h" />
+    <ClInclude Include="..\..\include\version_defs.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/MSVC/build/date.vcxproj.filters
+++ b/MSVC/build/date.vcxproj.filters
@@ -12,6 +12,9 @@
     <ClInclude Include="..\..\include\version.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\version_defs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\date\buildDate.cxx">

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
-			    BZFlag 2.4.31
-			 https://BZFlag.org/
+			      BZFlag 2.4.31
+			 https://www.BZFlag.org/
 		Copyright (c) 1993-2025 Tim Riker
 
 BZFlag is an Open Source OpenGL multiplayer multiplatform Battle Zone

--- a/README
+++ b/README
@@ -40,7 +40,7 @@ Table of Contents
 Obtaining BZFlag
 ================
 
-Main BZFlag Website:  http://BZFlag.org
+Main BZFlag Website:  http://www.BZFlag.org
 BZFlag Github Site:  https://github.com/BZFlag-Dev/bzflag
 
 The main BZFlag website provides access to most all of the resources

--- a/Xcode/BZFlag.xcodeproj/project.pbxproj
+++ b/Xcode/BZFlag.xcodeproj/project.pbxproj
@@ -1808,6 +1808,7 @@
 		03E42D121B321DF2006EE763 /* data */ = {isa = PBXFileReference; lastKnownFileType = folder; name = data; path = ../data; sourceTree = "<group>"; };
 		03E42D191B322DFC006EE763 /* COPYING */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = COPYING; path = ../COPYING; sourceTree = "<group>"; };
 		03FA742E1742601B00573D2D /* serverSidePlayerSample.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = serverSidePlayerSample.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C0F2ECB303F12A1005D1551 /* version_defs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = version_defs.h; sourceTree = "<group>"; };
 		C333EFC91E2B9F0800B4B182 /* customPollTypeSample.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = customPollTypeSample.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		C333EFCE1E2B9F5500B4B182 /* customPollTypeSample.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = customPollTypeSample.cpp; sourceTree = "<group>"; };
 		C333EFD31E2B9F5500B4B182 /* README.customPollTypeSample.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.customPollTypeSample.txt; sourceTree = "<group>"; };
@@ -2233,6 +2234,7 @@
 		0305D561166C9DAE00557FC4 /* include */ = {
 			isa = PBXGroup;
 			children = (
+				2C0F2ECB303F12A1005D1551 /* version_defs.h */,
 				0305D562166C9DAE00557FC4 /* AccessList.h */,
 				0305D563166C9DAE00557FC4 /* Address.h */,
 				0305D564166C9DAE00557FC4 /* AnsiCodes.h */,

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -149,6 +149,7 @@ noinst_HEADERS =			\
 	vectors.h			\
 	vectors_old.h			\
 	version.h			\
+	version_defs.h			\
 	win32.h
 
 

--- a/include/version.h
+++ b/include/version.h
@@ -16,8 +16,10 @@
 // 1st
 #include "common.h"
 
+#include "version_defs.h"
+
 #ifndef BZ_CONFIG_DIR_VERSION
-#define BZ_CONFIG_DIR_VERSION   "2.4"
+#define BZ_CONFIG_DIR_VERSION   BZ_STR(BZ_MAJOR_VERSION) "." BZ_STR(BZ_MINOR_VERSION)
 #endif
 
 #ifndef BZ_CONFIG_FILE_NAME

--- a/include/version_defs.h
+++ b/include/version_defs.h
@@ -1,0 +1,86 @@
+/* bzflag
+ * Copyright (c) 1993-2025 Tim Riker
+ *
+ * This package is free software;  you can redistribute it and/or
+ * modify it under the terms of the license found in the file
+ * named COPYING that should have accompanied this file.
+ *
+ * THIS PACKAGE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+// This file contains the protocol and version definitions, and some utility
+// macros used for assembling version strings. This file is parsed by NSIS and
+// scripts, so the formatting/whitespace around the definitions should not be
+// changed.
+
+#pragma once
+
+// opaque version number increments on protocol incompatibility
+// update the following files (and their protocol implementations) to match:
+//  misc/bzfquery.php
+//  misc/bzfquery.pl
+//  misc/bzfquery.py
+//  misc/bzls.lua
+#ifndef BZ_PROTO_VERSION
+#  define BZ_PROTO_VERSION  "0221"
+#endif
+
+// version numbers - also update as needed:
+//  ChangeLog
+//  README
+//  configure.ac
+//  include/version.h
+//  Xcode/BZFlag.xcodeproj/project.pbxproj
+//  Xcode/BZFlag-Info.plist
+#ifndef BZ_MAJOR_VERSION
+#  define BZ_MAJOR_VERSION 2
+#endif
+
+#ifndef BZ_MINOR_VERSION
+#  define BZ_MINOR_VERSION 4
+#endif
+
+#ifndef BZ_REV
+#  define BZ_REV 31
+#endif
+
+// DEVEL | ALPHA | BETA | RC | STABLE
+// DEVEL is used for typical unreleased or unfinished builds, like major dev versions (2.5.*)
+//   or odd revision numbers (2.4.33)
+// STABLE is for official stable releases, like 2.4.32, 2.4.34, etc
+// ALPHA, BETA, and RC are for dev versions approaching a release
+#ifndef BZ_BUILD_TYPE
+#  define BZ_BUILD_TYPE "DEVEL"
+#endif
+
+// Useful for ALPHA, BETA, and RC
+// For DEVEL and STABLE, this should be set to 0
+#ifndef BZ_BUILD_TYPE_REVISION
+#  define BZ_BUILD_TYPE_REVISION 0
+#endif
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// No need to modify the macros below. These are used inside of Version.rc on Windows. //
+/////////////////////////////////////////////////////////////////////////////////////////
+
+// Helper macros to convert numeric values to strings
+#define BZ_STR_HELPER(x) #x
+#define BZ_STR(x) BZ_STR_HELPER(x)
+
+// Automatically construct the version string: "MAJOR.MINOR.REV.0"
+#ifdef _WIN32
+#ifndef BZ_VERSION_STR
+#define BZ_VERSION_STR BZ_STR(BZ_MAJOR_VERSION) "." BZ_STR(BZ_MINOR_VERSION) "." BZ_STR(BZ_REV) ".0"
+#endif
+#endif
+
+// Local Variables: ***
+// mode: C++ ***
+// tab-width: 4 ***
+// c-basic-offset: 4 ***
+// indent-tabs-mode: nil ***
+// End: ***
+// ex: shiftwidth=4 tabstop=4

--- a/include/version_defs.h
+++ b/include/version_defs.h
@@ -31,7 +31,6 @@
 //  ChangeLog
 //  README
 //  configure.ac
-//  include/version.h
 //  Xcode/BZFlag.xcodeproj/project.pbxproj
 //  Xcode/BZFlag-Info.plist
 #ifndef BZ_MAJOR_VERSION

--- a/include/version_defs.h
+++ b/include/version_defs.h
@@ -30,9 +30,6 @@
 // version numbers - also update as needed:
 //  ChangeLog
 //  README
-//  configure.ac
-//  Xcode/BZFlag.xcodeproj/project.pbxproj
-//  Xcode/BZFlag-Info.plist
 #ifndef BZ_MAJOR_VERSION
 #  define BZ_MAJOR_VERSION 2
 #endif

--- a/include/version_defs.h
+++ b/include/version_defs.h
@@ -27,9 +27,8 @@
 #  define BZ_PROTO_VERSION  "0221"
 #endif
 
-// version numbers - also update as needed:
-//  ChangeLog
-//  README
+// Update the ChangeLog when you bump the version. Run misc/updateversion.py
+// to update the version in some other files.
 #ifndef BZ_MAJOR_VERSION
 #  define BZ_MAJOR_VERSION 2
 #endif

--- a/misc/updateversion.py
+++ b/misc/updateversion.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Update the BZFlag version in some project files to match what is contained
+# within version_defs.h
+#
+# This file is marked CC0 1.0 Universal. To view a copy of this mark, visit
+#   https://creativecommons.org/publicdomain/zero/1.0/
+
+import os
+import re
+import sys
+
+# Figure out the root path of the source tree
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Shortcut to get the relative path of a file
+def rel(path):
+	return os.path.relpath(path, ROOT)
+
+# Build and return the version triplet as defined in version_defs.h.
+def read_defined_version():
+	# Build the path and ensure the file exists
+	header_path = os.path.join(ROOT, "include", "version_defs.h")
+	if not os.path.isfile(header_path):
+		sys.exit("ERROR: %s not found" % rel(header_path))
+
+	# Read the contents of the file
+	with open(header_path, encoding="utf-8") as f:
+		text = f.read()
+
+	# Function to parse out a single definition that tries to be tolerant of whitespace changes
+	def get(name):
+		m = re.search(r"^\s*#\s*define\s+%s\s+(\d+)" % name, text, re.M)
+		if not m:
+			sys.exit("ERROR: %s not found (or not a plain integer) in %s" % (name, rel(header_path)))
+		return int(m.group(1))
+
+	# Return the version triplet
+	return "%d.%d.%d" % (get("BZ_MAJOR_VERSION"), get("BZ_MINOR_VERSION"), get("BZ_REV"))
+
+# Apply a regex replacement pattern to a file
+def update_file(path, pattern, replacement):
+	# Read the contents of the file
+	with open(path, encoding="utf-8") as f:
+		text = f.read()
+
+	# Run the replacement, storing a copy of the new text and a count of the matches found
+	new_text, count = re.subn(pattern, replacement, text)
+
+	# If we found 0 matches, something likely went wrong
+	if count == 0:
+		sys.exit("ERROR: No matches found in %s" % rel(path))
+
+	# If the new text matches the old text, then we might have already had the files updated, or something went wrong
+	if new_text == text:
+		print("  NOT updated: %s had no changes" % rel(path))
+	else:
+		with open(path, "w", encoding="utf-8") as f:
+			f.write(new_text)
+		print("  updated: %s (%d replacement%s)" % (rel(path), count, "s" if count != 1 else ""))
+
+def main():
+	# Get the version triplet
+	new_version = read_defined_version()
+	print("Version detected: %s" % new_version)
+	print()
+
+	# Define our replacements as an array of tuples, with the absolute file path, regex pattern, and regex replacement
+	replacements = [
+		# AC_INIT([BZFlag],[x.y.z],[...],[bzflag])
+		(
+			os.path.join(ROOT, "configure.ac"),
+			r"(\bAC_INIT\(\s*\[\s*BZFlag\s*\]\s*,\s*\[)([0-9]+\.[0-9]+\.[0-9]+)(\])",
+			r"\g<1>" + new_version + r"\g<3>"
+		),
+
+		# BZFlag-x.y.z and BZFlag-x.y.z.app (multiple occurrences)
+		(
+			os.path.join(ROOT, "Xcode", "BZFlag.xcodeproj", "project.pbxproj"),
+			r"\bBZFlag-[0-9]+\.[0-9]+\.[0-9]+",
+			r"BZFlag-" + new_version
+		),
+
+		# <key>CFBundleShortVersionString</key> immediately followed by <string>x.y.z</string> on the next line
+		(
+			os.path.join(ROOT, "Xcode", "BZFlag-Info.plist"),
+			r"(<key>\s*CFBundleShortVersionString\s*</key>\s*<string>)([0-9]+\.[0-9]+\.[0-9]+)(</string>)",
+			r"\g<1>" + new_version + r"\g<3>"
+		),
+	]
+
+	# First check that we can find all of these files, and bail out now if we can't
+	for path, _, _ in replacements:
+		if not os.path.isfile(path):
+			sys.exit("ERROR: %s not found" % rel(path))
+
+	# Now that we checked they exist, update the version number in each
+	print("Updating files:")
+	for path, pattern, replacement in replacements:
+		update_file(path, pattern, replacement)
+
+	# If we got this far, report success.
+	print()
+	print("Done! Please manually verify that the files were modified correctly.")
+
+if __name__ == "__main__":
+	main()

--- a/misc/updateversion.py
+++ b/misc/updateversion.py
@@ -100,7 +100,7 @@ def main():
 		if not os.path.isfile(path):
 			sys.exit("ERROR: %s not found" % rel(path))
 
-	# Now that we checked they exist, update the version number in each
+	# Now that we verified they exist, update the version number in each
 	print("Updating files:")
 	for path, pattern, replacement in replacements:
 		update_file(path, pattern, replacement)

--- a/misc/updateversion.py
+++ b/misc/updateversion.py
@@ -66,6 +66,13 @@ def main():
 
 	# Define our replacements as an array of tuples, with the absolute file path, regex pattern, and regex replacement
 	replacements = [
+		# BZFlag-x.y.z and BZFlag-x.y.z.app (multiple occurrences)
+		(
+			os.path.join(ROOT, "README"),
+			r"BZFlag [0-9]+\.[0-9]+\.[0-9]+",
+			r"BZFlag " + new_version
+		),
+
 		# AC_INIT([BZFlag],[x.y.z],[...],[bzflag])
 		(
 			os.path.join(ROOT, "configure.ac"),

--- a/package/win32/nsis/BZFlag.nsi
+++ b/package/win32/nsis/BZFlag.nsi
@@ -5,17 +5,12 @@
 ;--------------------------------
 ;BZFlag Version Variables
 
-  !define VER_MAJOR 2
-  !define VER_MINOR 4
-  !define VER_REVISION 31
-
-  ;!define TYPE "release"
-  ;!define TYPE "alpha"
-  ;!define TYPE "beta"
-  !define TYPE "devel"
-  ;!define TYPE "RC"
-
-  !define TYPE_REVISION "0"
+  ; Read the values out of version_defs.h
+  !searchparse /file ..\..\..\include\version_defs.h `#  define BZ_MAJOR_VERSION ` VER_MAJOR
+  !searchparse /file ..\..\..\include\version_defs.h `#  define BZ_MINOR_VERSION ` VER_MINOR
+  !searchparse /file ..\..\..\include\version_defs.h `#  define BZ_REV ` VER_REVISION
+  !searchparse /file ..\..\..\include\version_defs.h `#  define BZ_BUILD_TYPE "` BUILD_TYPE `"`
+  !searchparse /file ..\..\..\include\version_defs.h `#  define BZ_BUILD_TYPE_REVISION ` BUILD_TYPE_REVISION
 
   ;Allow manually specifying a date for the installer. This only works if the
   ;minor or revision version numbers are odd. Uses YYYYMMDD format. Uncomment
@@ -35,12 +30,12 @@
 ;Automatically generated version variables
 
   ; Include the date for alpha/beta/RC builds
-  !if ${TYPE} != "release"
-	!if ${TYPE} != "devel"
-		!define VERSION_TAIL "-${TYPE}${TYPE_REVISION}"
-	!else
-		!define VERSION_TAIL ""
-	!endif
+  !if ${BUILD_TYPE} != "STABLE"
+    !if ${BUILD_TYPE} != "DEVEL"
+      !define VERSION_TAIL "-${BUILD_TYPE}${BUILD_TYPE_REVISION}"
+    !else
+      !define VERSION_TAIL ""
+    !endif
     !ifndef DATE_OVERRIDE
       !define /date VERSION "${VER_MAJOR}.${VER_MINOR}.${VER_REVISION}.%Y%m%d${VERSION_TAIL}"
     !else
@@ -285,7 +280,7 @@ Section "!BZFlag (Required)" BZFlag
     SetOutPath $INSTDIR\documentation
     CreateDirectory "$SMPROGRAMS\$STARTMENU_FOLDER\Documentation"
     CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\Documentation\BZFlag [game] Manual Pages (HTML).lnk" "$INSTDIR\documentation\bzflag.html" "" "" 0
-	CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\Documentation\Credits.lnk" "$INSTDIR\documentation\Authors.txt" "" "" 0
+    CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\Documentation\Credits.lnk" "$INSTDIR\documentation\Authors.txt" "" "" 0
 
   !insertmacro MUI_STARTMENU_WRITE_END
 

--- a/src/date/buildDate.cxx
+++ b/src/date/buildDate.cxx
@@ -105,13 +105,14 @@ const char*     getAppVersion()
     if (!appVersion.size())
     {
         std::ostringstream  appVersionStream;
-        appVersionStream << getMajorMinorRevVersion() << "." << getBuildDate()
-                         << "-" << BZ_BUILD_TYPE
+        appVersionStream
+                << getMajorMinorRevVersion() << "." << getBuildDate()
+                << "-" << BZ_BUILD_TYPE
 #if BZ_BUILD_TYPE_REVISION > 0
-                         << BZ_BUILD_TYPE_REVISION;
+                << BZ_BUILD_TYPE_REVISION;
 #endif
-                         << "-" << BZ_BUILD_OS
-                         << "-SDL2";
+                << "-" << BZ_BUILD_OS
+                << "-SDL2";
         appVersion = appVersionStream.str();
     }
     return appVersion.c_str();

--- a/src/date/buildDate.cxx
+++ b/src/date/buildDate.cxx
@@ -12,49 +12,13 @@
 
 #include "common.h"
 #include "version.h"
+#include "version_defs.h"
 
 /* system headers */
 #include <sstream>
 #include <string>
 #include <stdio.h>
 #include <string.h>
-
-
-// opaque version number increments on protocol incompatibility
-// update the following files (and their protocol implementations) to match:
-//  misc/bzfquery.php
-//  misc/bzfquery.pl
-//  misc/bzfquery.py
-//  misc/bzls.lua
-#ifndef BZ_PROTO_VERSION
-#  define BZ_PROTO_VERSION  "0221"
-#endif
-
-// version numbers - also update as needed:
-//  ChangeLog
-//  MSVC/bzflag.rc
-//  README
-//  configure.ac
-//  include/version.h
-//  package/win32/nsis/BZFlag.nsi
-//  Xcode/BZFlag.xcodeproj/project.pbxproj
-//  Xcode/BZFlag-Info.plist
-#ifndef BZ_MAJOR_VERSION
-#  define BZ_MAJOR_VERSION  2
-#endif
-
-#ifndef BZ_MINOR_VERSION
-#  define BZ_MINOR_VERSION  4
-#endif
-
-#ifndef BZ_REV
-#  define BZ_REV        31
-#endif
-
-// DEVEL | RC# | STABLE | MAINT
-#ifndef BZ_BUILD_TYPE
-#  define BZ_BUILD_TYPE     "DEVEL"
-#endif
 
 const char *bzfcopyright = "Copyright (c) 1993-2025 Tim Riker";
 
@@ -141,9 +105,12 @@ const char*     getAppVersion()
     if (!appVersion.size())
     {
         std::ostringstream  appVersionStream;
-        // TODO add current platform, release, cpu, etc
         appVersionStream << getMajorMinorRevVersion() << "." << getBuildDate()
-                         << "-" << BZ_BUILD_TYPE << "-" << BZ_BUILD_OS
+                         << "-" << BZ_BUILD_TYPE;
+#if BZ_BUILD_TYPE_REVISION > 0
+        appVersionStream << BZ_BUILD_TYPE_REVISION;
+#endif
+        appVersionStream << "-" << BZ_BUILD_OS
                          << "-SDL2";
         appVersion = appVersionStream.str();
     }

--- a/src/date/buildDate.cxx
+++ b/src/date/buildDate.cxx
@@ -106,11 +106,11 @@ const char*     getAppVersion()
     {
         std::ostringstream  appVersionStream;
         appVersionStream << getMajorMinorRevVersion() << "." << getBuildDate()
-                         << "-" << BZ_BUILD_TYPE;
+                         << "-" << BZ_BUILD_TYPE
 #if BZ_BUILD_TYPE_REVISION > 0
-        appVersionStream << BZ_BUILD_TYPE_REVISION;
+                         << BZ_BUILD_TYPE_REVISION;
 #endif
-        appVersionStream << "-" << BZ_BUILD_OS
+                         << "-" << BZ_BUILD_OS
                          << "-SDL2";
         appVersion = appVersionStream.str();
     }


### PR DESCRIPTION
This simplifies the release process by moving the version definitions to a separate header file and then referencing this from other files. This header is directly used by the Windows resource file and the NSIS installer script, and used by a new python script that updates the version number in the README, configure.ac and the Xcode project files.

This splits the numeric part of BZ_BUILD_TYPE (for ALPHA, BETA, AND RC builds) into a separate BZ_BUILD_TYPE_REVISION definition. into This also changes our process a bit and uses "STABLE" for all releases from a stable branch instead of just using "STABLE" for the .0 release and "MAINT" for all subsequent releases.